### PR TITLE
Overser eventuelle null-verdier for vedlegg istedenfor å feile.

### DIFF
--- a/src/main/kotlin/no/nav/helse/soknad/Soknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Soknad.kt
@@ -13,7 +13,7 @@ data class Soknad(
     val barn: BarnDetaljer,
     val relasjonTilBarnet: String? = null,
     val arbeidsgivere: ArbeidsgiverDetaljer,
-    val vedlegg: List<URL>,
+    private val vedlegg: List<URL>,
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
     val medlemskap: Medlemskap,
@@ -26,7 +26,10 @@ data class Soknad(
     val tilsynsordning: Tilsynsordning?,
     val nattevaak: Nattevaak? = null,
     val beredskap: Beredskap? = null
-)
+) {
+    // Kan oppstå url = null etter Jackson deserialisering
+    internal fun vedlegg() = vedlegg.filterNotNull()
+}
 
 data class ArbeidsgiverDetaljer(
     val organisasjoner: List<OrganisasjonDetaljer>

--- a/src/main/kotlin/no/nav/helse/soknad/SoknadService.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SoknadService.kt
@@ -31,15 +31,15 @@ class SoknadService(private val pleiepengesoknadMottakGateway: PleiepengesoknadM
         logger.trace("Søker hentet. Validerer om søkeren.")
         soker.validate()
 
-        logger.trace("Validert Søker. Henter ${soknad.vedlegg.size} vedlegg.")
+        logger.trace("Validert Søker. Henter ${soknad.vedlegg().size} vedlegg.")
         val vedlegg = vedleggService.hentVedlegg(
             idToken = idToken,
-            vedleggUrls = soknad.vedlegg,
+            vedleggUrls = soknad.vedlegg(),
             callId = callId
         )
 
         logger.trace("Vedlegg hentet. Validerer vedleggene.")
-        vedlegg.validerVedlegg(soknad.vedlegg)
+        vedlegg.validerVedlegg(soknad.vedlegg())
 
         logger.trace("Legger søknad til prosessering")
 
@@ -78,7 +78,7 @@ class SoknadService(private val pleiepengesoknadMottakGateway: PleiepengesoknadM
         logger.trace("Søknad lagt til prosessering. Sletter vedlegg.")
 
         vedleggService.slettVedleg(
-            vedleggUrls = soknad.vedlegg,
+            vedleggUrls = soknad.vedlegg(),
             callId = callId,
             idToken = idToken
         )

--- a/src/main/kotlin/no/nav/helse/soknad/SoknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SoknadValidator.kt
@@ -4,7 +4,6 @@ import no.nav.helse.dusseldorf.ktor.core.*
 import no.nav.helse.vedlegg.Vedlegg
 import java.net.URL
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 private const val MAX_VEDLEGG_SIZE = 24 * 1024 * 1024 // 3 vedlegg på 8 MB
@@ -107,20 +106,19 @@ internal fun Soknad.validate() {
     ))
 
     // Vedlegg
-    if (vedlegg.isEmpty()) {
+    if (vedlegg().isEmpty()) {
         violations.add(
             Violation(
                 parameterName = "vedlegg",
                 parameterType = ParameterType.ENTITY,
                 reason = "Det må sendes minst et vedlegg.",
-                invalidValue = vedlegg
+                invalidValue = vedlegg()
             )
         )
     }
 
-    vedlegg.mapIndexed { index, url ->
-        // Kan oppstå url = null etter Jackson deserialisering
-        if (url == null || !url.path.matches(Regex("/vedlegg/.*"))) {
+    vedlegg().mapIndexed { index, url ->
+        if (!url.path.matches(Regex("/vedlegg/.*"))) {
             violations.add(
                 Violation(
                     parameterName = "vedlegg[$index]",

--- a/src/test/kotlin/no/nav/helse/SoknadUtils.kt
+++ b/src/test/kotlin/no/nav/helse/SoknadUtils.kt
@@ -8,8 +8,8 @@ class SoknadUtils {
             fodselsnummer: String,
             fraOgMed: String? = "2018-10-10",
             tilOgMed: String? = "2019-10-10",
-            vedleggUrl1: String,
-            vedleggUrl2: String,
+            vedleggUrl1: String?,
+            vedleggUrl2: String?,
             utenGrad: Boolean = false) : String {
             return """
                 {
@@ -34,8 +34,8 @@ class SoknadUtils {
                         ]
                     },
                     "vedlegg": [
-                        "$vedleggUrl1",
-                        "$vedleggUrl2"
+                        ${if (vedleggUrl1 != null) """"$vedleggUrl1"""" else null},
+                        ${if (vedleggUrl2 != null) """"$vedleggUrl2"""" else null}
                     ],
                     "medlemskap" : {
                         "har_bodd_i_utlandet_siste_12_mnd" : false,


### PR DESCRIPTION
Dette bør løse de "rare" 400-feilene vi har sett.
Da vil vi bare filtrere bort de eventuelle `null`-verdiene som settes fra klienten og behandle søknaden med de vedleggene som er satt.

Men feilen virker jo å være noe som oppstår i klienten, så er jo en viss sjanse for at søkeren i klienten oppfatter at den har lastet opp et vedlegg (som av ukjent grunn settes som `null` i klienten) og at man videre sender inn søknaden uten vedlegget søkeren har oppfattet at den har lastet opp.. Så det bør nok dikuteres litt før denne merges @frodehansen2  @ramrock93 

Har ikke testet en innsending i dev så det bør gjøres 