### PR TITLE
Utvider støtte for ny loginservice issuer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,42 +1,42 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "1.3.2.9c88b78"
+val dusseldorfKtorVersion = "1.4.1.7d8c082"
 val ktorVersion = ext.get("ktorVersion").toString()
 
 val mainClass = "no.nav.helse.AppKt"
 
 plugins {
-    kotlin("jvm") version "1.3.50"
-    id("com.github.johnrengelman.shadow") version "5.1.0"
+    kotlin("jvm") version "1.4.10"
+    id("com.github.johnrengelman.shadow") version "6.1.0"
 }
 
 buildscript {
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/9c88b788e57939fb6e3d18650393a7e9fb65960f/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/7d8c082e3fe5f0517f11498a6ab99cc80c9404a4/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {
     // Server
-    compile ( "no.nav.helse:dusseldorf-ktor-core:$dusseldorfKtorVersion")
-    compile ( "no.nav.helse:dusseldorf-ktor-jackson:$dusseldorfKtorVersion")
-    compile ( "no.nav.helse:dusseldorf-ktor-metrics:$dusseldorfKtorVersion")
-    compile ( "no.nav.helse:dusseldorf-ktor-health:$dusseldorfKtorVersion")
-    compile ( "no.nav.helse:dusseldorf-ktor-auth:$dusseldorfKtorVersion")
-    compile ("io.ktor:ktor-locations:$ktorVersion")
+    implementation ( "no.nav.helse:dusseldorf-ktor-core:$dusseldorfKtorVersion")
+    implementation ( "no.nav.helse:dusseldorf-ktor-jackson:$dusseldorfKtorVersion")
+    implementation ( "no.nav.helse:dusseldorf-ktor-metrics:$dusseldorfKtorVersion")
+    implementation ( "no.nav.helse:dusseldorf-ktor-health:$dusseldorfKtorVersion")
+    implementation ( "no.nav.helse:dusseldorf-ktor-auth:$dusseldorfKtorVersion")
+    implementation ("io.ktor:ktor-locations:$ktorVersion")
 
     // Client
-    compile ( "no.nav.helse:dusseldorf-ktor-client:$dusseldorfKtorVersion")
-    compile ( "no.nav.helse:dusseldorf-oauth2-client:$dusseldorfKtorVersion")
-    compile ("io.lettuce:lettuce-core:5.2.1.RELEASE")
+    implementation ( "no.nav.helse:dusseldorf-ktor-client:$dusseldorfKtorVersion")
+    implementation ( "no.nav.helse:dusseldorf-oauth2-client:$dusseldorfKtorVersion")
+    implementation ("io.lettuce:lettuce-core:5.2.1.RELEASE")
     implementation("com.github.fppt:jedis-mock:0.1.16")
 
     // Test
-    testCompile ( "no.nav.helse:dusseldorf-test-support:$dusseldorfKtorVersion")
-    testCompile ("io.ktor:ktor-server-test-host:$ktorVersion") {
+    testImplementation ( "no.nav.helse:dusseldorf-test-support:$dusseldorfKtorVersion")
+    testImplementation ("io.ktor:ktor-server-test-host:$ktorVersion") {
         exclude(group = "org.eclipse.jetty")
     }
 
-    testCompile ("org.skyscreamer:jsonassert:1.5.0")
+    testImplementation ("org.skyscreamer:jsonassert:1.5.0")
 }
 
 repositories {
@@ -86,5 +86,5 @@ tasks.withType<ShadowJar> {
 }
 
 tasks.withType<Wrapper> {
-    gradleVersion = "5.6.2"
+    gradleVersion = "6.7"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/nais/dev-sbs.json
+++ b/nais/dev-sbs.json
@@ -12,9 +12,8 @@
   "env": {
     "REDIS_HOST": "pleiepengesoknad-api-redis.default.svc.nais.local",
     "CORS_ADDRESSES": "https://pleiepengesoknad-q.nav.no,https://www-q0.nav.no",
-    "ISSUER": "https://login.microsoftonline.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/",
+    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navtestb2c.onmicrosoft.com/discovery/v2.0/.well-known/openid-configuration?p=b2c_1a_idporten_ver1",
     "COOKIE_NAME": "selvbetjening-idtoken",
-    "JWKS_URI": "https://login.microsoftonline.com/navtestb2c.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1a_idporten_ver1",
     "K9_OPPSLAG_REGISTER_URL": "https://api-gw-q1.oera.no/helse-reverse-proxy/k9-selvbetjening-oppslag",
     "PLEIEPENGESOKNAD_MOTTAK_BASE_URL": "https://api-gw-q1.oera.no/helse-reverse-proxy/pleiepengesoknad-mottak",
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.oera-q.local",

--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -44,3 +44,5 @@ spec:
     - name: {{@key}}
       value: "{{this}}"
   {{/each}}
+  envFrom:
+    - configmap: loginservice-idporten

--- a/nais/prod-sbs.json
+++ b/nais/prod-sbs.json
@@ -12,9 +12,8 @@
   "env": {
     "REDIS_HOST": "pleiepengesoknad-api-redis.default.svc.nais.local",
     "CORS_ADDRESSES": "https://pleiepengesoknad.nav.no,https://www.nav.no",
-    "ISSUER": "https://login.microsoftonline.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/",
+    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navnob2c.onmicrosoft.com/discovery/v2.0/.well-known/openid-configuration?p=b2c_1a_idporten",
     "COOKIE_NAME": "selvbetjening-idtoken",
-    "JWKS_URI": "https://login.microsoftonline.com/navnob2c.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1a_idporten",
     "K9_OPPSLAG_REGISTER_URL": "https://api-gw.oera.no/helse-reverse-proxy/k9-selvbetjening-oppslag",
     "PLEIEPENGESOKNAD_MOTTAK_BASE_URL": "https://api-gw.oera.no/helse-reverse-proxy/pleiepengesoknad-mottak",
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.oera.no",

--- a/src/main/kotlin/no/nav/helse/App.kt
+++ b/src/main/kotlin/no/nav/helse/App.kt
@@ -8,20 +8,15 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.application.*
-import io.ktor.auth.Authentication
-import io.ktor.auth.authenticate
-import io.ktor.auth.jwt.JWTPrincipal
-import io.ktor.auth.jwt.jwt
+import io.ktor.auth.*
+import io.ktor.auth.jwt.*
 import io.ktor.features.*
-import io.ktor.http.HttpMethod
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.Url
-import io.ktor.jackson.jackson
-import io.ktor.locations.KtorExperimentalLocationsAPI
-import io.ktor.locations.Locations
-import io.ktor.metrics.micrometer.MicrometerMetrics
-import io.ktor.routing.Routing
-import io.ktor.util.KtorExperimentalAPI
+import io.ktor.http.*
+import io.ktor.jackson.*
+import io.ktor.locations.*
+import io.ktor.metrics.micrometer.*
+import io.ktor.routing.*
+import io.ktor.util.*
 import io.prometheus.client.hotspot.DefaultExports
 import no.nav.helse.arbeidsgiver.ArbeidsgivereGateway
 import no.nav.helse.arbeidsgiver.ArbeidsgivereService
@@ -99,11 +94,14 @@ fun Application.pleiepengesoknadapi() {
     }
 
     val idTokenProvider = IdTokenProvider(cookieName = configuration.getCookieName())
+    //TODO: Kan fjernes etter no/nav/helse/App.kt:108
     val jwkProvider = JwkProviderBuilder(configuration.getJwksUrl().toURL())
         .cached(10, 24, TimeUnit.HOURS)
         .rateLimited(10, 1, TimeUnit.MINUTES)
         .build()
 
+    //TODO: refaktorer lik: https://github.com/navikt/dusseldorf-ktor/pull/154#issue-508876256
+    //TODO: issuers kan hentes lik https://github.com/navikt/k9-selvbetjening-oppslag/blob/b3c94359f07c1f0e9304e078f1e3db9ed241ee38/src/main/kotlin/no/nav/k9/SelvbetjeningOppslag.kt#L45
     install(Authentication) {
         jwt {
             realm = appId

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -1,27 +1,44 @@
 package no.nav.helse
 
-import io.ktor.config.ApplicationConfig
-import io.ktor.util.KtorExperimentalAPI
+import io.ktor.config.*
+import io.ktor.util.*
+import kotlinx.coroutines.runBlocking
 import no.nav.helse.dusseldorf.ktor.core.getOptionalList
 import no.nav.helse.dusseldorf.ktor.core.getOptionalString
 import no.nav.helse.dusseldorf.ktor.core.getRequiredList
 import no.nav.helse.dusseldorf.ktor.core.getRequiredString
 import no.nav.helse.general.auth.ApiGatewayApiKey
+import org.json.simple.JSONObject
+import org.json.simple.parser.JSONParser
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.net.URI
+import java.net.URL
+
+private const val ISSUER = "issuer"
+private const val JWKS_URI = "jwks_uri"
+
+private val jsonParser = JSONParser()
+private val logger: Logger = LoggerFactory.getLogger("no.nav.helse.Configuration")
 
 @KtorExperimentalAPI
-data class Configuration(val config : ApplicationConfig) {
-    internal fun getJwksUrl() = URI(config.getRequiredString("nav.authorization.jwks_uri", secret = false))
+data class Configuration(val config: ApplicationConfig) {
 
-    internal fun getIssuer() : String {
-        return config.getRequiredString("nav.authorization.issuer", secret = false)
-    }
+    private val discoveryJson =
+        runBlocking { config.getRequiredString("nav.authorization.loginservice_discovery_url", false).discover(listOf(ISSUER, JWKS_URI)) }
 
-    internal fun getCookieName() : String {
+    private val issuer = discoveryJson[ISSUER] as String
+    private val jwksUrl = discoveryJson[JWKS_URI] as String
+
+    internal fun getJwksUrl() = URI(jwksUrl)
+
+    internal fun getIssuer(): String = issuer
+
+    internal fun getCookieName(): String {
         return config.getRequiredString("nav.authorization.cookie_name", secret = false)
     }
 
-    internal fun getWhitelistedCorsAddreses() : List<URI> {
+    internal fun getWhitelistedCorsAddreses(): List<URI> {
         return config.getOptionalList(
             key = "nav.cors.addresses",
             builder = { value ->
@@ -35,19 +52,37 @@ data class Configuration(val config : ApplicationConfig) {
 
     internal fun getK9DokumentUrl() = URI(config.getRequiredString("nav.gateways.k9_dokument_url", secret = false))
 
-    internal fun getPleiepengesoknadMottakBaseUrl() = URI(config.getRequiredString("nav.gateways.pleiepengesoknad_mottak_base_url", secret = false))
+    internal fun getPleiepengesoknadMottakBaseUrl() =
+        URI(config.getRequiredString("nav.gateways.pleiepengesoknad_mottak_base_url", secret = false))
 
-    internal fun getApiGatewayApiKey() : ApiGatewayApiKey {
+    internal fun getApiGatewayApiKey(): ApiGatewayApiKey {
         val apiKey = config.getRequiredString(key = "nav.authorization.api_gateway.api_key", secret = true)
         return ApiGatewayApiKey(value = apiKey)
     }
 
-    private fun getScopesFor(operation: String) = config.getRequiredList("nav.auth.scopes.$operation", secret = false, builder = { it }).toSet()
+    private fun getScopesFor(operation: String) =
+        config.getRequiredList("nav.auth.scopes.$operation", secret = false, builder = { it }).toSet()
+
     internal fun getSendSoknadTilProsesseringScopes() = getScopesFor("sende-soknad-til-prosessering")
     internal fun getRedisPort() = config.getOptionalString("nav.redis.port", secret = false)
     internal fun getRedisHost() = config.getOptionalString("nav.redis.host", secret = false)
 
-    internal fun getStoragePassphrase() : String {
+    internal fun getStoragePassphrase(): String {
         return config.getRequiredString("nav.storage.passphrase", secret = true)
     }
+}
+
+private fun String.discover(requiredAttributes: List<String>): JSONObject {
+    val asText = URL(this).readText()
+    val asJson = jsonParser.parse(asText) as JSONObject
+    return if (asJson.containsKeys(requiredAttributes)) asJson else {
+        throw IllegalStateException("Response fra Discovery Endpoint inneholdt ikke attributtene '[${requiredAttributes.joinToString()}]'. Response='$asText'\"")
+    }
+}
+
+private fun JSONObject.containsKeys(requiredAttributes: List<String>): Boolean {
+    requiredAttributes.forEach {
+        if (!containsKey(it)) return false
+    }
+    return true
 }

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -15,9 +15,11 @@ import org.slf4j.LoggerFactory
 import java.net.URI
 import java.net.URL
 
+//TODO: Kan fjernes etter no/nav/helse/App.kt:108
 private const val ISSUER = "issuer"
 private const val JWKS_URI = "jwks_uri"
 
+//TODO: Kan fjernes etter no/nav/helse/App.kt:108
 private val jsonParser = JSONParser()
 private val logger: Logger = LoggerFactory.getLogger("no.nav.helse.Configuration")
 
@@ -30,8 +32,10 @@ data class Configuration(val config: ApplicationConfig) {
     private val issuer = discoveryJson[ISSUER] as String
     private val jwksUrl = discoveryJson[JWKS_URI] as String
 
+    //TODO: Kan fjernes etter no/nav/helse/App.kt:108
     internal fun getJwksUrl() = URI(jwksUrl)
 
+    //TODO: Kan fjernes etter no/nav/helse/App.kt:108
     internal fun getIssuer(): String = issuer
 
     internal fun getCookieName(): String {
@@ -72,6 +76,7 @@ data class Configuration(val config: ApplicationConfig) {
     }
 }
 
+//TODO: Kan fjernes etter no/nav/helse/App.kt:108
 private fun String.discover(requiredAttributes: List<String>): JSONObject {
     val asText = URL(this).readText()
     val asJson = jsonParser.parse(asText) as JSONObject
@@ -80,6 +85,7 @@ private fun String.discover(requiredAttributes: List<String>): JSONObject {
     }
 }
 
+//TODO: Kan fjernes etter no/nav/helse/App.kt:108
 private fun JSONObject.containsKeys(requiredAttributes: List<String>): Boolean {
     requiredAttributes.forEach {
         if (!containsKey(it)) return false

--- a/src/main/kotlin/no/nav/helse/general/auth/AuthorizationStatusPages.kt
+++ b/src/main/kotlin/no/nav/helse/general/auth/AuthorizationStatusPages.kt
@@ -1,9 +1,10 @@
 package no.nav.helse.general.auth
 
-import io.ktor.application.call
-import io.ktor.features.StatusPages
-import io.ktor.http.HttpStatusCode
-import io.ktor.response.respond
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.response.*
+import no.nav.helse.dusseldorf.ktor.auth.ClaimEnforcementFailed
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -13,12 +14,11 @@ import org.slf4j.LoggerFactory
     isn’t authorized to perform the requested operation on the given resource.
  */
 
-private val logger: Logger = LoggerFactory.getLogger("nav.authorizationStatusPages")
+private val logger: Logger = LoggerFactory.getLogger("no.nav.helse.general.auth.AuthorizationStatusPagesKt.IdTokenStatusPages")
 
+fun StatusPages.Configuration.IdTokenStatusPages() {
 
-fun StatusPages.Configuration.authorizationStatusPages() {
-
-    exception<InsufficientAuthenticationLevelException> { cause ->
+    exception<ClaimEnforcementFailed> { cause ->
         call.respond(HttpStatusCode.Forbidden)
         // Kan ha vært logget inn på en annen NAV-tjeneste som ikke krever nivå 4 i forkant
         // og må nå logge inn på nytt. Trenger ikke å logge noe error på dette

--- a/src/main/kotlin/no/nav/helse/general/auth/IdToken.kt
+++ b/src/main/kotlin/no/nav/helse/general/auth/IdToken.kt
@@ -1,20 +1,13 @@
 package no.nav.helse.general.auth
 
 import com.auth0.jwt.JWT
-import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.http.auth.*
 
 data class IdToken(val value: String) {
     private val jwt = try {
         JWT.decode(value)
     } catch (cause: Throwable) {
         throw IdTokenInvalidFormatException(this, cause)
-    }
-
-    internal fun medValidertLevel(required: String) : IdToken {
-        val acr = jwt.getClaim("acr")
-        if (acr?.asString() == null) throw IdTokenInvalidFormatException(this)
-        return if (required == acr.asString()) this
-        else throw InsufficientAuthenticationLevelException(actualAcr = acr.asString(), requiredAcr = required)
     }
 
     internal fun somHttpAuthHeader() : HttpAuthHeader = HttpAuthHeader.Single("Bearer", value)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -44,10 +44,8 @@ nav {
             api_key = ""
             api_key = ${?API_GATEWAY_API_KEY}
         }
-        jwks_uri = ""
-        jwks_uri = ${?JWKS_URI}
-        issuer = ""
-        issuer = ${?ISSUER}
+        loginservice_discovery_url = ""
+        loginservice_discovery_url = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
         cookie_name = ""
         cookie_name = ${?COOKIE_NAME}
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -34,6 +34,17 @@ nav {
             discovery_endpoint = ""
             discovery_endpoint = ${?AZURE_V2_DISCOVERY_ENDPOINT}
         }]
+        issuers = [{
+           alias = "login-service-v1"
+           discovery_endpoint = ""
+           discovery_endpoint = ${?LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT}
+       },{
+           alias = "login-service-v2"
+           discovery_endpoint = ""
+           discovery_endpoint = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
+           audience = ""
+           audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
+       }]
         scopes = {
             sende-soknad-til-prosessering = ""
             sende-soknad-til-prosessering = ${?SENDE_SOKNAD_TIL_PROSESSERING_SCOPES}
@@ -44,8 +55,6 @@ nav {
             api_key = ""
             api_key = ${?API_GATEWAY_API_KEY}
         }
-        loginservice_discovery_url = ""
-        loginservice_discovery_url = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
         cookie_name = ""
         cookie_name = ${?COOKIE_NAME}
     }

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -2,22 +2,20 @@ package no.nav.helse
 
 import com.github.tomakehurst.wiremock.http.Cookie
 import com.typesafe.config.ConfigFactory
-import io.ktor.config.ApplicationConfig
-import io.ktor.config.HoconApplicationConfig
+import io.ktor.config.*
 import io.ktor.http.*
-import io.ktor.server.testing.TestApplicationEngine
-import io.ktor.server.testing.createTestEnvironment
-import io.ktor.server.testing.handleRequest
-import io.ktor.server.testing.setBody
-import io.ktor.util.KtorExperimentalAPI
+import io.ktor.server.testing.*
+import io.ktor.util.*
 import no.nav.helse.dusseldorf.ktor.core.fromResources
 import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.helse.redis.RedisMockUtil
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.Næringstyper
+import no.nav.helse.soknad.Regnskapsfører
+import no.nav.helse.soknad.Virksomhet
+import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
 import no.nav.helse.wiremock.*
 import org.junit.AfterClass
 import org.junit.BeforeClass
-import org.junit.Ignore
 import org.skyscreamer.jsonassert.JSONAssert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -233,13 +231,11 @@ class ApplicationTest {
                     "invalid_parameters": [{
                         "type": "query",
                         "name": "fra_og_med",
-                        "reason": "Må settes og være på gyldig format (YYYY-MM-DD)",
-                        "invalid_value": null
+                        "reason": "Må settes og være på gyldig format (YYYY-MM-DD)"
                     }, {
                         "type": "query",
                         "name": "til_og_med",
-                        "reason": "Må settes og være på og gyldig format (YYYY-MM-DD)",
-                        "invalid_value": null
+                        "reason": "Må settes og være på og gyldig format (YYYY-MM-DD)"
                     }]
                 }
             """.trimIndent()
@@ -521,8 +517,7 @@ class ApplicationTest {
                         {
                           "type": "entity",
                           "name": "selvstendigVirksomheter[0].registrertIUtlandet",
-                          "reason": "Hvis registrertINorge er false må registrertIUtlandet være satt",
-                          "invalid_value": null
+                          "reason": "Hvis registrertINorge er false må registrertIUtlandet være satt"
                         }
                       ]
                     }
@@ -654,8 +649,7 @@ class ApplicationTest {
                     {
                       "type": "entity",
                       "name": "selvstendigVirksomheter[0].registrertIUtlandet",
-                      "reason": "Hvis registrertINorge er false må registrertIUtlandet være satt",
-                      "invalid_value": null
+                      "reason": "Hvis registrertINorge er false må registrertIUtlandet være satt"
                     }
                   ]
                 }
@@ -716,8 +710,7 @@ class ApplicationTest {
                       "skalJobbe": "ja",
                       "organisasjonsnummer": "917755736",
                       "jobberNormaltTimer": 0.0,
-                      "skalJobbeProsent": 99.0,
-                      "vetIkkeEkstrainfo": null
+                      "skalJobbeProsent": 99.0
                     }
                   ]
                 }
@@ -761,8 +754,7 @@ class ApplicationTest {
                       "skalJobbe": "redusert",
                       "organisasjonsnummer": "917755736",
                       "jobberNormaltTimer": 0.0,
-                      "skalJobbeProsent": 100.0,
-                      "vetIkkeEkstrainfo": null
+                      "skalJobbeProsent": 100.0
                     }
                   ]
                 }
@@ -806,8 +798,7 @@ class ApplicationTest {
                       "skalJobbe": "nei",
                       "organisasjonsnummer": "917755736",
                       "jobberNormaltTimer": 0.0,
-                      "skalJobbeProsent": 10.0,
-                      "vetIkkeEkstrainfo": null
+                      "skalJobbeProsent": 10.0
                     }
                   ]
                 }
@@ -851,8 +842,7 @@ class ApplicationTest {
                       "skalJobbe": "vetIkke",
                       "organisasjonsnummer": "917755736",
                       "jobberNormaltTimer": 0.0,
-                      "skalJobbeProsent": 10.0,
-                      "vetIkkeEkstrainfo": null
+                      "skalJobbeProsent": 10.0
                     }
                   ]
                 }
@@ -1023,26 +1013,22 @@ class ApplicationTest {
                     {
                       "type": "entity",
                       "name": "vedlegg[1]",
-                      "reason": "Ikke gyldig vedlegg URL.",
-                      "invalid_value": null
+                      "reason": "Ikke gyldig vedlegg URL."
                     },
                     {
                       "type": "entity",
                       "name": "medlemskap.harBoddIUtlandetSiste12Mnd",
-                      "reason": "Må settes til true eller false.",
-                      "invalid_value": null
+                      "reason": "Må settes til true eller false."
                     },
                     {
                       "type": "entity",
                       "name": "medlemskap.skalBoIUtlandetNeste12Mnd",
-                      "reason": "Må settes til true eller false.",
-                      "invalid_value": null
+                      "reason": "Må settes til true eller false."
                     },
                     {
                       "type": "entity",
                       "name": "harMedsøker",
-                      "reason": "Må settes til true eller false.",
-                      "invalid_value": null
+                      "reason": "Må settes til true eller false."
                     },
                     {
                       "type": "entity",
@@ -1081,8 +1067,7 @@ class ApplicationTest {
                     {
                       "type": "entity",
                       "name": "bekrefterPeriodeOver8Uker",
-                      "reason": "Hvis perioden er over 8 uker(40 virkedager) må bekrefterPeriodeOver8Uker være true",
-                      "invalid_value": null
+                      "reason": "Hvis perioden er over 8 uker(40 virkedager) må bekrefterPeriodeOver8Uker være true"
                     }
                   ]
                 }

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -21,13 +21,10 @@ object TestConfiguration {
         corsAdresses : String = "http://localhost:8080"
     ) : Map<String, String> {
 
-        val loginServiceWellKnownJson = wireMockServer?.getLoginServiceV1WellKnownUrl()?.getAsJson()
-
         val map = mutableMapOf(
             Pair("ktor.deployment.port","$port"),
-            Pair("nav.authorization.issuer", "${loginServiceWellKnownJson?.getString("issuer")}"),
+            Pair("nav.authorization.loginservice_discovery_url", "${wireMockServer?.getLoginServiceV1WellKnownUrl()}"),
             Pair("nav.authorization.cookie_name", "localhost-idtoken"),
-            Pair("nav.authorization.jwks_uri","${loginServiceWellKnownJson?.getString("jwks_uri")}"),
             Pair("nav.gateways.k9_oppslag_url","$k9OppslagUrl"),
             Pair("nav.gateways.pleiepengesoknad_mottak_base_url", "$pleiepengesoknadMottakUrl"),
             Pair("nav.gateways.k9_dokument_url", "$k9DokumentUrl"),

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -1,14 +1,13 @@
 package no.nav.helse
 
-import com.github.kittinunf.fuel.httpGet
 import com.github.tomakehurst.wiremock.WireMockServer
 import no.nav.helse.dusseldorf.testsupport.jws.ClientCredentials
+import no.nav.helse.dusseldorf.testsupport.jws.LoginService
 import no.nav.helse.dusseldorf.testsupport.wiremock.getAzureV2WellKnownUrl
 import no.nav.helse.dusseldorf.testsupport.wiremock.getLoginServiceV1WellKnownUrl
 import no.nav.helse.wiremock.getK9DokumentUrl
 import no.nav.helse.wiremock.getK9OppslagUrl
 import no.nav.helse.wiremock.getPleiepengesoknadMottakUrl
-import org.json.JSONObject
 
 object TestConfiguration {
 
@@ -23,7 +22,6 @@ object TestConfiguration {
 
         val map = mutableMapOf(
             Pair("ktor.deployment.port","$port"),
-            Pair("nav.authorization.loginservice_discovery_url", "${wireMockServer?.getLoginServiceV1WellKnownUrl()}"),
             Pair("nav.authorization.cookie_name", "localhost-idtoken"),
             Pair("nav.gateways.k9_oppslag_url","$k9OppslagUrl"),
             Pair("nav.gateways.pleiepengesoknad_mottak_base_url", "$pleiepengesoknadMottakUrl"),
@@ -40,6 +38,12 @@ object TestConfiguration {
             map["nav.auth.clients.0.certificate_hex_thumbprint"] = ClientCredentials.ClientA.certificateHexThumbprint
             map["nav.auth.clients.0.discovery_endpoint"] = wireMockServer.getAzureV2WellKnownUrl()
             map["nav.auth.scopes.sende-soknad-til-prosessering"] = "pleiepengesoknad-mottak/.default"
+
+            map["nav.auth.issuers.0.alias"] = "login-service-v1"
+            map["nav.auth.issuers.0.discovery_endpoint"] = wireMockServer.getLoginServiceV1WellKnownUrl()
+            map["nav.auth.issuers.1.alias"] = "login-service-v2"
+            map["nav.auth.issuers.1.discovery_endpoint"] = wireMockServer.getLoginServiceV1WellKnownUrl()
+            map["nav.auth.issuers.1.audience"] = LoginService.V1_0.getAudience()
         }
 
         map["nav.redis.host"] = "localhost"
@@ -48,6 +52,4 @@ object TestConfiguration {
 
         return map.toMap()
     }
-
-    private fun String.getAsJson() = JSONObject(this.httpGet().responseString().third.component1())
 }


### PR DESCRIPTION
- konfigurer opp støtte for loginservice issuer v1 og v2.
- Erstatter jwt authententication med authentication med multiple issuers fra dusseldorf-ktor.