### PR TITLE
Fikser mellomlagring.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     }
 
     testImplementation ("org.skyscreamer:jsonassert:1.5.0")
+    testImplementation("org.awaitility:awaitility-kotlin:4.0.3")
+
 }
 
 repositories {

--- a/src/main/kotlin/no/nav/helse/mellomlagring/Mellomlagring.kt
+++ b/src/main/kotlin/no/nav/helse/mellomlagring/Mellomlagring.kt
@@ -39,14 +39,12 @@ fun Route.mellomlagringApis(
         val idToken = idTokenProvider.getIdToken(call)
         val mellomlagring = mellomlagringService.getMellomlagring(idToken.getSubject()!!)
         if (mellomlagring != null) {
-            logger.info("Mellomlagret søknad hentet.")
             call.respondText(
                 contentType = ContentType.Application.Json,
                 text = mellomlagring,
                 status = HttpStatusCode.OK
             )
         } else {
-            logger.info("Mellomlagret søknad ikke funnet.")
             call.respondText(
                 contentType = ContentType.Application.Json,
                 text = "{}",

--- a/src/main/kotlin/no/nav/helse/mellomlagring/Mellomlagring.kt
+++ b/src/main/kotlin/no/nav/helse/mellomlagring/Mellomlagring.kt
@@ -39,12 +39,14 @@ fun Route.mellomlagringApis(
         val idToken = idTokenProvider.getIdToken(call)
         val mellomlagring = mellomlagringService.getMellomlagring(idToken.getSubject()!!)
         if (mellomlagring != null) {
+            logger.info("Mellomlagret søknad hentet.")
             call.respondText(
                 contentType = ContentType.Application.Json,
                 text = mellomlagring,
                 status = HttpStatusCode.OK
             )
         } else {
+            logger.info("Mellomlagret søknad ikke funnet.")
             call.respondText(
                 contentType = ContentType.Application.Json,
                 text = "{}",

--- a/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
+++ b/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
@@ -28,7 +28,7 @@ class MellomlagringService @KtorExperimentalAPI constructor(
         fnr: String,
         midlertidigSøknad: String,
         expirationDate: Date = Calendar.getInstance().let {
-            it.add(Calendar.HOUR, 24)
+            it.add(Calendar.MINUTE, 10)
             it.time
         }
     ) {

--- a/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
+++ b/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
@@ -28,7 +28,7 @@ class MellomlagringService @KtorExperimentalAPI constructor(
         fnr: String,
         midlertidigSøknad: String,
         expirationDate: Date = Calendar.getInstance().let {
-            it.add(Calendar.MINUTE, 10)
+            it.add(Calendar.HOUR, 24)
             it.time
         }
     ) {

--- a/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
+++ b/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
@@ -49,4 +49,6 @@ class MellomlagringService @KtorExperimentalAPI constructor(
     ) {
         redisStore.delete(nøkkelPrefiks + fnr)
     }
+
+    fun getTTL(fnr: String): Long = redisStore.getTTL(nøkkelPrefiks + fnr)
 }

--- a/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
+++ b/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
@@ -27,8 +27,8 @@ class RedisStore constructor(
         val set = async.set(key, value)
 
         if (set.await(10, TimeUnit.SECONDS)) {
-            val timoutSet = async.pexpireat(key, expirationDate)
-            timoutSet.whenComplete { t: Boolean, _: Throwable ->  logger.info("Expiry set = $t")}
+            val expirationSet = async.pexpireat(key, expirationDate).get()
+            if (!expirationSet) throw IllegalStateException("Feilet med å sette expiry på key.")
             return set.get()
         }
 

--- a/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
+++ b/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
@@ -29,7 +29,8 @@ class RedisStore constructor(
         if (set.await(10, TimeUnit.SECONDS)) {
             val expirationSet = async.pexpireat(key, expirationDate).get()
             if (!expirationSet) throw IllegalStateException("Feilet med å sette expiry på key.")
-            else logger.info("Expiration satt på key")
+            else logger.info("Expiration satt på key med TTL=${async.pttl(key).get()}")
+
             return set.get()
         }
 

--- a/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
+++ b/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
@@ -29,7 +29,7 @@ class RedisStore constructor(
         if (set.await(10, TimeUnit.SECONDS)) {
             val expirationSet = async.pexpireat(key, expirationDate).get()
             if (!expirationSet) throw IllegalStateException("Feilet med å sette expiry på key.")
-            else logger.info("Expiration satt på key med TTL=${async.pttl(key).get()}")
+            else logger.info("Expiration satt på key med PTTL=${async.pttl(key).get()}")
 
             return set.get()
         }
@@ -47,7 +47,7 @@ class RedisStore constructor(
 
         return null
     }
-
+K
     fun delete(key: String): Boolean {
         val del = async.del(key)
 

--- a/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
+++ b/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
@@ -47,7 +47,7 @@ class RedisStore constructor(
 
         return null
     }
-K
+
     fun delete(key: String): Boolean {
         val del = async.del(key)
 

--- a/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
+++ b/src/main/kotlin/no/nav/helse/redis/RedisStore.kt
@@ -29,6 +29,7 @@ class RedisStore constructor(
         if (set.await(10, TimeUnit.SECONDS)) {
             val expirationSet = async.pexpireat(key, expirationDate).get()
             if (!expirationSet) throw IllegalStateException("Feilet med å sette expiry på key.")
+            else logger.info("Expiration satt på key")
             return set.get()
         }
 

--- a/src/test/kotlin/no/nav/helse/mellomlagring/MellomlagringTest.kt
+++ b/src/test/kotlin/no/nav/helse/mellomlagring/MellomlagringTest.kt
@@ -1,28 +1,22 @@
 package no.nav.helse.mellomlagring
 
 import com.github.fppt.jedismock.RedisServer
-import com.typesafe.config.ConfigFactory
-import io.ktor.config.*
 import io.ktor.util.*
-import no.nav.helse.Configuration
-import no.nav.helse.TestConfiguration
-import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
-import no.nav.helse.mellomlagring.MellomlagringTest.Companion.redisClient
 import no.nav.helse.redis.RedisConfig
-import no.nav.helse.redis.RedisConfigurationProperties
-import no.nav.helse.redis.RedisMockUtil
 import no.nav.helse.redis.RedisStore
-import no.nav.helse.wiremock.*
+import org.awaitility.Awaitility
+import org.awaitility.Durations.ONE_SECOND
 import org.junit.AfterClass
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
+import org.slf4j.LoggerFactory
+import java.util.*
+import kotlin.test.*
 
 @KtorExperimentalAPI
 class MellomlagringTest {
 
     private companion object {
+        val logger = LoggerFactory.getLogger(MellomlagringTest::class.java)
+
         val redisServer: RedisServer = RedisServer
             .newRedisServer(6379)
             .started()
@@ -57,6 +51,26 @@ class MellomlagringTest {
         val mellomlagring = mellomlagringService.getMellomlagring("test")
 
         assertEquals("test", mellomlagring)
+    }
+
+    @Test
+    internal fun `mellomlagret verdier skal være utgått etter 500 ms`() {
+        val fnr = "12345678910"
+        val søknad = "test"
+
+        mellomlagringService.setMellomlagring(fnr, søknad, expirationDate = Calendar.getInstance().let {
+            it.add(Calendar.MILLISECOND, 500)
+            it.time
+        })
+        val forventetVerdi1 = mellomlagringService.getMellomlagring(fnr)
+        logger.info("Hentet mellomlagret verdi = {}", forventetVerdi1)
+        assertEquals("test", forventetVerdi1)
+
+        Awaitility.waitAtMost(ONE_SECOND).untilAsserted {
+            val forventetVerdi2 = mellomlagringService.getMellomlagring(fnr)
+            logger.info("Hentet mellomlagret verdi = {}", forventetVerdi2)
+            assertNull(forventetVerdi2)
+        }
     }
 
     @Test


### PR DESCRIPTION
Når man oppretter key for første gang får man en expire på 24 timer.
Andre gang den blir kalt uten expire, fører til at expire slettes på key.

For å unngå at man utvider den opprinnelige expire tiden, og at den ikke slettet, henter man TTL på key som viser gjenstående tid. Deretter oppgir man en ny expiry med ny tid som består av TTL.
https://redis.io/commands/expire 

Testet dialog med en utløpstid på 10 min for å forsikre ønsket oppførsel.