### PR TITLE
Legger til mapping av omsorgstilbud dersom den ikke er satt.

### DIFF
--- a/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
@@ -78,7 +78,7 @@ fun Søknad.byggK9DataBruktTilUtledning(): DataBruktTilUtledning = DataBruktTilU
     harBekreftetOpplysninger,
     samtidigHjemme,
     harMedsøker,
-    bekrefterPeriodeOver8Uker
+    null
 )
 
 fun Søknad.byggK9Omsorg() = Omsorg()

--- a/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
@@ -52,9 +52,11 @@ fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker): K9Søknad {
     beredskap?.let { if (it.beredskap) psb.medBeredskap(beredskap.tilK9Beredskap(søknadsperiode)) }
     nattevåk?.let { if (it.harNattevåk == true) psb.medNattevåk(nattevåk.tilK9Nattevåk(søknadsperiode)) }
     omsorgstilbud?.let {
-        if (it.fasteDager != null) psb.medTilsynsordning(omsorgstilbud.tilK9TilsynsordningFasteDager(søknadsperiode))
-        if (it.enkeltDager != null) psb.medTilsynsordning(omsorgstilbud.tilK9TilsynsordningEnkeltDager())
-    }
+        if (it.fasteDager == null && it.enkeltDager == null) psb.medTilsynsordning(tilK9Tilsynsordning0Timer(søknadsperiode))
+        if (it.fasteDager != null) psb.medTilsynsordning(it.tilK9TilsynsordningFasteDager(søknadsperiode))
+        if (it.enkeltDager != null) psb.medTilsynsordning(it.tilK9TilsynsordningEnkeltDager())
+    } ?: psb.medTilsynsordning(tilK9Tilsynsordning0Timer(søknadsperiode))
+
     ferieuttakIPerioden?.let {
         if (it.ferieuttak.isNotEmpty() && it.skalTaUtFerieIPerioden) {
             psb.medLovbestemtFerie(ferieuttakIPerioden.tilK9LovbestemtFerie())
@@ -129,6 +131,16 @@ fun Omsorgstilbud.tilK9TilsynsordningFasteDager(periode: Periode) = K9Tilsynsord
             )
         }
     }
+}
+
+
+fun tilK9Tilsynsordning0Timer(periode: Periode) = K9Tilsynsordning().apply {
+    leggeTilPeriode(
+        periode,
+        TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(
+            Duration.ZERO
+        )
+    )
 }
 
 fun Omsorgstilbud.tilK9TilsynsordningEnkeltDager() = K9Tilsynsordning().apply {

--- a/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
@@ -17,7 +17,6 @@ data class KomplettSøknad(
     val arbeidsgivere: ArbeidsgiverDetaljer,
     val vedlegg: List<Vedlegg> = listOf(), // TODO: Fjern listof() når krav om legeerklæring er påkrevd igjen.
     val medlemskap: Medlemskap,
-    val bekrefterPeriodeOver8Uker: Boolean? = null,
     val utenlandsoppholdIPerioden: UtenlandsoppholdIPerioden?,
     val ferieuttakIPerioden: FerieuttakIPerioden?,
     val harMedsøker: Boolean? = null,

--- a/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
@@ -21,7 +21,6 @@ data class Søknad(
     @JsonFormat(pattern = "yyyy-MM-dd")
     val tilOgMed: LocalDate,
     val medlemskap: Medlemskap,
-    val bekrefterPeriodeOver8Uker: Boolean? = null,// TODO: Fjern optional når prodsatt.
     val utenlandsoppholdIPerioden: UtenlandsoppholdIPerioden?,
     val ferieuttakIPerioden: FerieuttakIPerioden?,
     val harMedsøker: Boolean? = null,

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadService.kt
@@ -55,7 +55,6 @@ class SøknadService(
             vedlegg = vedlegg,
             arbeidsgivere = søknad.arbeidsgivere,
             medlemskap = søknad.medlemskap,
-            bekrefterPeriodeOver8Uker = søknad.bekrefterPeriodeOver8Uker,
             ferieuttakIPerioden = søknad.ferieuttakIPerioden,
             utenlandsoppholdIPerioden = søknad.utenlandsoppholdIPerioden,
             harMedsøker = søknad.harMedsøker!!,

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -13,7 +13,6 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
 private const val MAX_VEDLEGG_SIZE = 24 * 1024 * 1024 // 3 vedlegg på 8 MB
-private const val ANTALL_VIRKEDAGER_8_UKER = 40
 private val vedleggTooLargeProblemDetails = DefaultProblemDetails(
     title = "attachments-too-large",
     status = 413,
@@ -150,23 +149,6 @@ internal fun Søknad.validate(k9FormatSøknad: no.nav.k9.søknad.Søknad) {
                     parameterType = ParameterType.ENTITY,
                     reason = "Ikke gyldig vedlegg URL.",
                     invalidValue = url
-                )
-            )
-        }
-    }
-
-    // Booleans (For å forsikre at de er satt og ikke blir default false)
-
-    //Validerer at brukeren bekrefter dersom perioden er over 8 uker (40 virkedager)
-    if (bekrefterPeriodeOver8Uker != null) {
-        val antallVirkedagerIPerioden = antallVirkedagerIEnPeriode(fraOgMed, tilOgMed)
-
-        if (antallVirkedagerIPerioden > ANTALL_VIRKEDAGER_8_UKER && !bekrefterPeriodeOver8Uker) {
-            violations.add(
-                Violation(
-                    parameterName = "bekrefterPeriodeOver8Uker",
-                    parameterType = ParameterType.ENTITY,
-                    reason = "Hvis perioden er over 8 uker(40 virkedager) må bekrefterPeriodeOver8Uker være true"
                 )
             )
         }

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -1351,42 +1351,6 @@ class ApplicationTest {
     }
 
     @Test
-    fun `Sende søknad hvor perioden er over 8 uker(40 virkedager) og man har ikke godkjent det, skal feile`() {
-        val cookie = getAuthCookie(gyldigFodselsnummerA)
-        val jpegUrl = engine.jpegUrl(cookie)
-
-        requestAndAssert(
-            httpMethod = HttpMethod.Post,
-            path = "/soknad",
-            expectedResponse = """
-                {
-                  "type": "/problem-details/invalid-request-parameters",
-                  "title": "invalid-request-parameters",
-                  "status": 400,
-                  "detail": "Requesten inneholder ugyldige paramtere.",
-                  "instance": "about:blank",
-                  "invalid_parameters": [
-                    {
-                      "type": "entity",
-                      "name": "bekrefterPeriodeOver8Uker",
-                      "reason": "Hvis perioden er over 8 uker(40 virkedager) må bekrefterPeriodeOver8Uker være true",
-                        "invalid_value": null
-                    }
-                  ]
-                }
-            """.trimIndent(),
-            expectedCode = HttpStatusCode.BadRequest,
-            cookie = cookie,
-            requestEntity = SøknadUtils.bodyMedJusterbarTilOgFraOgBekrefterPeriodeOver8Uker(
-                vedleggUrl1 = jpegUrl,
-                fraOgMed = "2020-01-01",
-                tilOgMed = "2020-02-27",
-                bekrefterPeriodeOver8Uker = false
-            )
-        )
-    }
-
-    @Test
     fun `Sende søknad med omsorgstilbud, der søker vet alle timer, men både fasteDager og enkeltDager er null`() {
         val cookie = getAuthCookie(gyldigFodselsnummerA)
 

--- a/src/test/kotlin/no/nav/helse/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/helse/SerDesTest.kt
@@ -95,7 +95,6 @@ internal class SerDesTest {
             vedlegg = listOf(URL("http://localhost:8080/vedlegg/1")),
             fraOgMed = LocalDate.now(),
             tilOgMed = LocalDate.now().plusDays(10),
-            bekrefterPeriodeOver8Uker = true,
             nattevåk = Nattevåk(
                 harNattevåk = true,
                 tilleggsinformasjon = "Har nattevåk"
@@ -397,7 +396,6 @@ internal class SerDesTest {
               "skalBekrefteOmsorg": true,
               "skalPassePåBarnetIHelePerioden": true,
               "beskrivelseOmsorgsrollen": "En kort beskrivelse",
-              "bekrefterPeriodeOver8Uker": true,
               "beredskap": {
                 "beredskap": true,
                 "tilleggsinformasjon": "Ikke beredskap"
@@ -608,7 +606,6 @@ internal class SerDesTest {
               "skalBekrefteOmsorg": true,
               "skalPassePåBarnetIHelePerioden": true,
               "beskrivelseOmsorgsrollen": "En kort beskrivelse",
-              "bekrefterPeriodeOver8Uker": true,
               "beredskap": {
                 "beredskap": true,
                 "tilleggsinformasjon": "Ikke beredskap"
@@ -683,7 +680,6 @@ internal class SerDesTest {
             ),
             fraOgMed = LocalDate.parse("2020-01-01"),
             tilOgMed = LocalDate.parse("2020-02-01"),
-            bekrefterPeriodeOver8Uker = true,
             nattevåk = Nattevåk(
                 harNattevåk = true,
                 tilleggsinformasjon = "Har nattevåk"

--- a/src/test/kotlin/no/nav/helse/SoknadValidationTest.kt
+++ b/src/test/kotlin/no/nav/helse/SoknadValidationTest.kt
@@ -2,7 +2,20 @@ package no.nav.helse
 
 import no.nav.helse.dusseldorf.ktor.core.Throwblem
 import no.nav.helse.k9format.tilK9Format
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.Arbeidsform
+import no.nav.helse.soknad.ArbeidsgiverDetaljer
+import no.nav.helse.soknad.BarnDetaljer
+import no.nav.helse.soknad.BarnRelasjon
+import no.nav.helse.soknad.Bosted
+import no.nav.helse.soknad.FerieuttakIPerioden
+import no.nav.helse.soknad.Frilans
+import no.nav.helse.soknad.Medlemskap
+import no.nav.helse.soknad.OrganisasjonDetaljer
+import no.nav.helse.soknad.SkalJobbe
+import no.nav.helse.soknad.Språk
+import no.nav.helse.soknad.Søknad
+import no.nav.helse.soknad.UtenlandsoppholdIPerioden
+import no.nav.helse.soknad.validate
 import java.net.URL
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -61,14 +74,6 @@ class SoknadValidationTest {
     @Test
     fun `Søknad hvor perioden er 40 virkedager, skal ikke feile`(){
         val søknad = soknadMedFrilans(fraOgMed = LocalDate.parse("2020-01-01"), tilOgMed = LocalDate.parse("2020-02-26"))
-        val k9Format = søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker)
-
-        søknad.validate(k9Format)
-    }
-
-    @Test(expected = Throwblem::class)
-    fun `Søknad hvor perioden er 41 virkedager hvor det ikke er bekreftet, skal feile`(){
-        val søknad = soknadMedFrilans(fraOgMed = LocalDate.parse("2020-01-01"), tilOgMed = LocalDate.parse("2020-02-27"))
         val k9Format = søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker)
 
         søknad.validate(k9Format)
@@ -134,7 +139,6 @@ class SoknadValidationTest {
         vedlegg = listOf(URL("http://localhost:8080/vedlegg/1")),
         fraOgMed = fraOgMed,
         tilOgMed = tilOgMed,
-        bekrefterPeriodeOver8Uker = bekrefterPeriodeOver8Uker,
         medlemskap = Medlemskap(
             harBoddIUtlandetSiste12Mnd = false,
             skalBoIUtlandetNeste12Mnd = true

--- a/src/test/kotlin/no/nav/helse/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/helse/SøknadUtils.kt
@@ -489,7 +489,6 @@ class SøknadUtils {
             vedlegg = listOf(URL("http://localhost:8080/vedlegg/1")),
             fraOgMed = LocalDate.parse("2020-01-01"),
             tilOgMed = LocalDate.parse("2020-01-20"),
-            bekrefterPeriodeOver8Uker = true,
             nattevåk = no.nav.helse.soknad.Nattevåk(
                 harNattevåk = true,
                 tilleggsinformasjon = "Har nattevåk"

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -59,7 +59,7 @@ class K9FormatTest {
                   "harBekreftetOpplysninger" : true,
                   "samtidigHjemme" : true,
                   "harMedsøker" : true,
-                  "bekrefterPeriodeOver8Uker" : true
+                  "bekrefterPeriodeOver8Uker" : null
                 },
                 "barn" : {
                   "norskIdentitetsnummer" : "03028104560",

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -319,6 +319,27 @@ class K9FormatTest {
     }
 
     @Test
+    fun `gitt søknadsperiode man-fre, uten tilsyn, forvent 1 periode med 0 timer`() {
+        val k9Tilsynsordning = tilK9Tilsynsordning0Timer(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+
+        assertEquals(1, k9Tilsynsordning.perioder.size)
+
+        JSONAssert.assertEquals(
+            //language=json
+            """
+            {
+              "perioder" : {
+                "2021-01-04/2021-01-08" : {
+                  "etablertTilsynTimerPerDag" : "PT0S"
+                }
+              },
+              "perioderSomSkalSlettes": {}
+            }
+        """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true
+        )
+    }
+
+    @Test
     fun `gitt søknadsperiode man-fre, tilsyn 10t alle dager, forvent 5 perioder med 7t 30m`() {
         val k9Tilsynsordning = Omsorgstilbud(
             fasteDager = OmsorgstilbudFasteDager(

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -210,7 +210,7 @@ class K9FormatTest {
                 fredag = Duration.ofHours(5)
             ),
             vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
-        ).tilK9TilsynsordningFasteDager(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+        ).tilK9Tilsynsordning(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
 
         assertEquals(5, k9Tilsynsordning.perioder.size)
 
@@ -251,7 +251,7 @@ class K9FormatTest {
                 fredag = Duration.ofHours(5)
             ),
             vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
-        ).tilK9TilsynsordningFasteDager(Periode(LocalDate.parse("2021-01-06"), LocalDate.parse("2021-01-11")))
+        ).tilK9Tilsynsordning(Periode(LocalDate.parse("2021-01-06"), LocalDate.parse("2021-01-11")))
 
         assertEquals(4, k9Tilsynsordning.perioder.size)
 
@@ -290,7 +290,7 @@ class K9FormatTest {
                 fredag = Duration.ofHours(5)
             ),
             vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
-        ).tilK9TilsynsordningFasteDager(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+        ).tilK9Tilsynsordning(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
 
         assertEquals(4, k9Tilsynsordning.perioder.size)
 
@@ -350,7 +350,7 @@ class K9FormatTest {
                 fredag = Duration.ofHours(10)
             ),
             vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
-        ).tilK9TilsynsordningFasteDager(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+        ).tilK9Tilsynsordning(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
 
         assertEquals(5, k9Tilsynsordning.perioder.size)
 


### PR DESCRIPTION
Dersom omsorgstilbud er null eller at både fasteDager og enkeltDager er null, sendes det 1 periode (søknadsperioden) med 0 timer.

- Fjerner feltet bekrefterPeriodeOver8Uker da den ikke lenger er nødvendig.


Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>