### PR TITLE
Gjør det mulig å bruke valideringsendepunktet før bruker har bekreftet opplysninger.

### DIFF
--- a/src/main/kotlin/no/nav/helse/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadApis.kt
@@ -83,7 +83,7 @@ fun Route.soknadApis(
         søknad.oppdaterBarnMedFnr(listeOverBarnMedFnr)
 
         val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
-        søknad.validate(k9FormatSøknad)
+        søknad.validate(k9FormatSøknad, false)
 
         val vedlegg = vedleggService.hentVedlegg(
             idToken = idToken,

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -96,7 +96,7 @@ class FraOgMedTilOgMedValidator {
     }
 }
 
-internal fun Søknad.validate(k9FormatSøknad: no.nav.k9.søknad.Søknad) {
+internal fun Søknad.validate(k9FormatSøknad: no.nav.k9.søknad.Søknad, skalValidereHarBekreftetOpplysninger: Boolean = true) {
     val violations = barn.validate()
 
     violations.addAll(arbeidsgivere.organisasjoner.validate())
@@ -160,7 +160,7 @@ internal fun Søknad.validate(k9FormatSøknad: no.nav.k9.søknad.Søknad) {
     violations.addAll(validerFerieuttakIPerioden(ferieuttakIPerioden))
     violations.addAll(nullSjekk(harMedsøker, "harMedsøker"))
 
-    if (!harBekreftetOpplysninger) {
+    if (skalValidereHarBekreftetOpplysninger && !harBekreftetOpplysninger) {
         violations.add(
             Violation(
                 parameterName = "harBekreftetOpplysninger",

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -9,33 +9,15 @@ import io.ktor.server.testing.*
 import no.nav.helse.dusseldorf.ktor.core.fromResources
 import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.helse.mellomlagring.started
-import no.nav.helse.soknad.Arbeidsforhold
-import no.nav.helse.soknad.Arbeidsform
-import no.nav.helse.soknad.Land
-import no.nav.helse.soknad.Næringstyper
-import no.nav.helse.soknad.Omsorgstilbud
-import no.nav.helse.soknad.OmsorgstilbudEnkeltDag
-import no.nav.helse.soknad.OmsorgstilbudFasteDager
-import no.nav.helse.soknad.Regnskapsfører
-import no.nav.helse.soknad.SkalJobbe
-import no.nav.helse.soknad.VetOmsorgstilbud
-import no.nav.helse.soknad.Virksomhet
-import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
-import no.nav.helse.wiremock.pleiepengesoknadApiConfig
-import no.nav.helse.wiremock.stubK9Mellomlagring
-import no.nav.helse.wiremock.stubK9MellomlagringHealth
-import no.nav.helse.wiremock.stubK9OppslagArbeidsgivere
-import no.nav.helse.wiremock.stubK9OppslagBarn
-import no.nav.helse.wiremock.stubK9OppslagSoker
-import no.nav.helse.wiremock.stubLeggSoknadTilProsessering
-import no.nav.helse.wiremock.stubOppslagHealth
-import no.nav.helse.wiremock.stubPleiepengesoknadMottakHealth
+import no.nav.helse.soknad.*
+import no.nav.helse.wiremock.*
 import org.json.JSONObject
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.skyscreamer.jsonassert.JSONAssert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.net.URL
 import java.time.Duration
 import java.time.LocalDate
 import java.util.*
@@ -460,6 +442,21 @@ class ApplicationTest {
                 vedleggUrl1 = jpegUrl,
                 vedleggUrl2 = pdfUrl
             )
+        )
+    }
+
+    @Test
+    fun `Validere søknad før innsending hvor harBekreftetOpplysninger er false`(){
+        val cookie = getAuthCookie(gyldigFodselsnummerA)
+        val jpegUrl = engine.jpegUrl(cookie)
+
+        requestAndAssert(
+            httpMethod = HttpMethod.Post,
+            path = VALIDERING_URL,
+            expectedResponse = null,
+            expectedCode = HttpStatusCode.Accepted,
+            cookie = cookie,
+            requestEntity = SøknadUtils.defaultSøknad().copy(harBekreftetOpplysninger = false, vedlegg = listOf<URL>(URL(jpegUrl))).somJson()
         )
     }
 


### PR DESCRIPTION
Siden frontend ønsker å sjekke om søknaden er gyldig før bruker har bekreftet opplysninger. 