### PR TITLE
Legger til nytt felt for Omsorgstilbud (omsorgstilbudV2).

### DIFF
--- a/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
@@ -160,7 +160,7 @@ fun OmsorgstilbudV2.tilK9Tilsynsordning(periode: Periode): K9Tilsynsordning = K9
 
     if (historisk == null && planlagt == null) return tilK9Tilsynsordning0Timer(periode)
 
-    historisk?.enkeltDager?.map {
+    historisk?.enkeltdager?.map {
         leggeTilPeriode(
             Periode(it.dato, it.dato),
             TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(

--- a/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
@@ -23,7 +23,8 @@ data class KomplettSøknad(
     val samtidigHjemme: Boolean?,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,
-    val omsorgstilbud: Omsorgstilbud? = null,
+    val omsorgstilbud: Omsorgstilbud? = null, // TODO: 18/08/2021 Blir erstattet med omsorgstilbudV2 etter prodsetting .
+    val omsorgstilbudV2: OmsorgstilbudV2? = null,
     val nattevåk: Nattevåk?,
     val beredskap: Beredskap?,
     val frilans: Frilans? = null,

--- a/src/main/kotlin/no/nav/helse/soknad/Omsorgstilbud.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Omsorgstilbud.kt
@@ -4,8 +4,23 @@ import java.time.Duration
 import java.time.LocalDate
 
 data class Omsorgstilbud(
-    val fasteDager: OmsorgstilbudFasteDager? = null,
+    val fasteDager: OmsorgstilbudUkedager? = null,
     val enkeltDager: List<OmsorgstilbudEnkeltDag>? = null,
+    val vetOmsorgstilbud: VetOmsorgstilbud
+)
+
+data class OmsorgstilbudV2(
+    val historisk: HistoriskOmsorgstilbud? = null,
+    val planlagt: PlanlagtOmsorgstilbud? = null
+)
+
+data class HistoriskOmsorgstilbud(
+    val enkeltDager: List<OmsorgstilbudEnkeltDag>
+)
+
+data class PlanlagtOmsorgstilbud(
+    val enkeltDager: List<OmsorgstilbudEnkeltDag>? = null,
+    val ukedager: OmsorgstilbudUkedager? = null,
     val vetOmsorgstilbud: VetOmsorgstilbud
 )
 
@@ -20,7 +35,7 @@ data class OmsorgstilbudEnkeltDag(
     val tid: Duration
 )
 
-data class OmsorgstilbudFasteDager(
+data class OmsorgstilbudUkedager(
     val mandag: Duration? = null,
     val tirsdag: Duration? = null,
     val onsdag: Duration? = null,

--- a/src/main/kotlin/no/nav/helse/soknad/Omsorgstilbud.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Omsorgstilbud.kt
@@ -15,11 +15,11 @@ data class OmsorgstilbudV2(
 )
 
 data class HistoriskOmsorgstilbud(
-    val enkeltDager: List<OmsorgstilbudEnkeltDag>
+    val enkeltdager: List<OmsorgstilbudEnkeltDag>
 )
 
 data class PlanlagtOmsorgstilbud(
-    val enkeltDager: List<OmsorgstilbudEnkeltDag>? = null,
+    val enkeltdager: List<OmsorgstilbudEnkeltDag>? = null,
     val ukedager: OmsorgstilbudUkedager? = null,
     val vetOmsorgstilbud: VetOmsorgstilbud
 )

--- a/src/main/kotlin/no/nav/helse/soknad/Omsorgstilbud.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Omsorgstilbud.kt
@@ -21,7 +21,8 @@ data class HistoriskOmsorgstilbud(
 data class PlanlagtOmsorgstilbud(
     val enkeltdager: List<OmsorgstilbudEnkeltDag>? = null,
     val ukedager: OmsorgstilbudUkedager? = null,
-    val vetOmsorgstilbud: VetOmsorgstilbud
+    val vetOmsorgstilbud: VetOmsorgstilbud,
+    val erLiktHverDag: Boolean? = null
 )
 
 enum class VetOmsorgstilbud {

--- a/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
@@ -27,7 +27,8 @@ data class Søknad(
     val samtidigHjemme: Boolean? = null,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,
-    val omsorgstilbud: Omsorgstilbud? = null,
+    val omsorgstilbud: Omsorgstilbud? = null, // TODO: 18/08/2021 Blir erstattet med omsorgstilbudV2 etter prodsetting .
+    val omsorgstilbudV2: OmsorgstilbudV2? = null,
     val nattevåk: Nattevåk? = null,
     val beredskap: Beredskap? = null,
     val frilans: Frilans? = null,

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadService.kt
@@ -64,6 +64,7 @@ class SøknadService(
             harBekreftetOpplysninger = søknad.harBekreftetOpplysninger,
             harForståttRettigheterOgPlikter = søknad.harForståttRettigheterOgPlikter,
             omsorgstilbud = søknad.omsorgstilbud,
+            omsorgstilbudV2 = søknad.omsorgstilbudV2,
             nattevåk = søknad.nattevåk,
             beredskap = søknad.beredskap,
             frilans = søknad.frilans,

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -1,6 +1,11 @@
 package no.nav.helse.soknad
 
-import no.nav.helse.dusseldorf.ktor.core.*
+import no.nav.helse.dusseldorf.ktor.core.DefaultProblemDetails
+import no.nav.helse.dusseldorf.ktor.core.ParameterType
+import no.nav.helse.dusseldorf.ktor.core.Throwblem
+import no.nav.helse.dusseldorf.ktor.core.ValidationProblemDetails
+import no.nav.helse.dusseldorf.ktor.core.Violation
+import no.nav.helse.utils.erLikEllerEtterDagensDato
 import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn
 import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarnValidator
 import java.time.LocalDate
@@ -103,6 +108,7 @@ internal fun Søknad.validate(k9FormatSøknad: no.nav.k9.søknad.Søknad) {
     violations.addAll(validerSelvstendigVirksomheter(selvstendigVirksomheter, selvstendigArbeidsforhold))
 
     omsorgstilbud?.apply { violations.addAll(this.validate()) }
+    omsorgstilbudV2?.apply { violations.addAll(this.validate()) }
 
     violations.addAll(validerBarnRelasjon())
 
@@ -380,8 +386,9 @@ private fun validerFerieuttakIPerioden(ferieuttakIPerioden: FerieuttakIPerioden?
     return violations
 }
 
+// TODO: 18/08/2021 Utgår. Blir erstattet med OmsorgstilbudV2.validate().
 fun Omsorgstilbud.validate() = mutableSetOf<Violation>().apply {
-    when(val vet = vetOmsorgstilbud) {
+    when (val vet = vetOmsorgstilbud) {
         VetOmsorgstilbud.VET_IKKE -> {
             if (fasteDager != null || (enkeltDager != null && enkeltDager.isNotEmpty())) {
                 add(
@@ -416,6 +423,52 @@ fun Omsorgstilbud.validate() = mutableSetOf<Violation>().apply {
                         invalidValue = "enkeltDager = $enkeltDager, fasteDager = $fasteDager"
                     )
                 )
+            }
+        }
+    }
+}
+
+fun OmsorgstilbudV2.validate() = mutableSetOf<Violation>().apply {
+
+    if (historisk != null && historisk.enkeltDager.isNotEmpty()) {
+        if (historisk.enkeltDager.any() { it.dato.erLikEllerEtterDagensDato() }) {
+            add(
+                Violation(
+                    parameterName = "omsorgstilbudV2.historisk.enkeltDager",
+                    parameterType = ParameterType.ENTITY,
+                    reason = "Historiske enkeltdager inneholder datoer som er enten lik eller senere enn dagens dato.",
+                    invalidValue = "enkeltDager = ${historisk.enkeltDager}"
+                )
+            )
+        }
+    }
+
+    if (planlagt != null) {
+        when (val vet = planlagt.vetOmsorgstilbud) {
+            VetOmsorgstilbud.VET_IKKE -> {
+                if (planlagt.ukedager != null || (planlagt.enkeltDager != null && planlagt.enkeltDager.isNotEmpty())) {
+                    add(
+                        Violation(
+                            parameterName = "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltDager",
+                            parameterType = ParameterType.ENTITY,
+                            reason = "Dersom vetOmsorgstilbud er '$vet', så kan verken 'ukedager' eller 'enkeltDager' være satt.",
+                            invalidValue = "enkeltDager = ${planlagt.enkeltDager}, ukedager = ${planlagt.ukedager}"
+                        )
+                    )
+                }
+            }
+
+            else -> {
+                if (planlagt.ukedager == null && planlagt.enkeltDager.isNullOrEmpty()) {
+                    add(
+                        Violation(
+                            parameterName = "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltDager",
+                            parameterType = ParameterType.ENTITY,
+                            reason = "Dersom vetOmsorgstilbud er '$vet', så må enten 'ukedager' eller 'enkeltDager' være satt.",
+                            invalidValue = "enkeltDager = ${planlagt.enkeltDager}, ukedager = ${planlagt.ukedager}"
+                        )
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -430,14 +430,14 @@ fun Omsorgstilbud.validate() = mutableSetOf<Violation>().apply {
 
 fun OmsorgstilbudV2.validate() = mutableSetOf<Violation>().apply {
 
-    if (historisk != null && historisk.enkeltDager.isNotEmpty()) {
-        if (historisk.enkeltDager.any() { it.dato.erLikEllerEtterDagensDato() }) {
+    if (historisk != null && historisk.enkeltdager.isNotEmpty()) {
+        if (historisk.enkeltdager.any() { it.dato.erLikEllerEtterDagensDato() }) {
             add(
                 Violation(
-                    parameterName = "omsorgstilbudV2.historisk.enkeltDager",
+                    parameterName = "omsorgstilbudV2.historisk.enkeltdager",
                     parameterType = ParameterType.ENTITY,
                     reason = "Historiske enkeltdager inneholder datoer som er enten lik eller senere enn dagens dato.",
-                    invalidValue = "enkeltDager = ${historisk.enkeltDager}"
+                    invalidValue = "enkeltdager = ${historisk.enkeltdager}"
                 )
             )
         }
@@ -446,26 +446,26 @@ fun OmsorgstilbudV2.validate() = mutableSetOf<Violation>().apply {
     if (planlagt != null) {
         when (val vet = planlagt.vetOmsorgstilbud) {
             VetOmsorgstilbud.VET_IKKE -> {
-                if (planlagt.ukedager != null || (planlagt.enkeltDager != null && planlagt.enkeltDager.isNotEmpty())) {
+                if (planlagt.ukedager != null || (planlagt.enkeltdager != null && planlagt.enkeltdager.isNotEmpty())) {
                     add(
                         Violation(
-                            parameterName = "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltDager",
+                            parameterName = "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltdager",
                             parameterType = ParameterType.ENTITY,
-                            reason = "Dersom vetOmsorgstilbud er '$vet', så kan verken 'ukedager' eller 'enkeltDager' være satt.",
-                            invalidValue = "enkeltDager = ${planlagt.enkeltDager}, ukedager = ${planlagt.ukedager}"
+                            reason = "Dersom vetOmsorgstilbud er '$vet', så kan verken 'ukedager' eller 'enkeltdager' være satt.",
+                            invalidValue = "enkeltdager = ${planlagt.enkeltdager}, ukedager = ${planlagt.ukedager}"
                         )
                     )
                 }
             }
 
             else -> {
-                if (planlagt.ukedager == null && planlagt.enkeltDager.isNullOrEmpty()) {
+                if (planlagt.ukedager == null && planlagt.enkeltdager.isNullOrEmpty()) {
                     add(
                         Violation(
                             parameterName = "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltDager",
                             parameterType = ParameterType.ENTITY,
                             reason = "Dersom vetOmsorgstilbud er '$vet', så må enten 'ukedager' eller 'enkeltDager' være satt.",
-                            invalidValue = "enkeltDager = ${planlagt.enkeltDager}, ukedager = ${planlagt.ukedager}"
+                            invalidValue = "enkeltDager = ${planlagt.enkeltdager}, ukedager = ${planlagt.ukedager}"
                         )
                     )
                 }

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -462,10 +462,10 @@ fun OmsorgstilbudV2.validate() = mutableSetOf<Violation>().apply {
                 if (planlagt.ukedager == null && planlagt.enkeltdager.isNullOrEmpty()) {
                     add(
                         Violation(
-                            parameterName = "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltDager",
+                            parameterName = "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltdager",
                             parameterType = ParameterType.ENTITY,
-                            reason = "Dersom vetOmsorgstilbud er '$vet', så må enten 'ukedager' eller 'enkeltDager' være satt.",
-                            invalidValue = "enkeltDager = ${planlagt.enkeltdager}, ukedager = ${planlagt.ukedager}"
+                            reason = "Dersom vetOmsorgstilbud er '$vet', så må enten 'ukedager' eller 'enkeltdager' være satt.",
+                            invalidValue = "enkeltdager = ${planlagt.enkeltdager}, ukedager = ${planlagt.ukedager}"
                         )
                     )
                 }

--- a/src/main/kotlin/no/nav/helse/utils/DateUtils.kt
+++ b/src/main/kotlin/no/nav/helse/utils/DateUtils.kt
@@ -1,0 +1,5 @@
+package no.nav.helse.utils
+
+import java.time.LocalDate
+
+fun LocalDate.erLikEllerEtterDagensDato() = isEqual(LocalDate.now()) || isAfter(LocalDate.now())

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -1443,9 +1443,8 @@ class ApplicationTest {
         )
     }
 
-    // TODO: 18/08/2021 Utgår etter at omsorgstilbud fjernes.
     @Test
-    fun `Sende søknad med omsorgstilbudV2, der søker vet alle planlagte timer, men både ukedager og enkeltDager er null`() {
+    fun `Sende søknad med omsorgstilbudV2, der søker vet alle planlagte timer, men både ukedager og enkeltdager er null`() {
         val cookie = getAuthCookie(gyldigFodselsnummerA)
 
         requestAndAssert(
@@ -1461,9 +1460,9 @@ class ApplicationTest {
                   "invalid_parameters": [
                     {
                       "type": "entity",
-                      "name": "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltDager",
-                      "reason": "Dersom vetOmsorgstilbud er 'VET_ALLE_TIMER', så må enten 'ukedager' eller 'enkeltDager' være satt.",
-                      "invalid_value": "enkeltDager = null, ukedager = null"
+                      "name": "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltdager",
+                      "reason": "Dersom vetOmsorgstilbud er 'VET_ALLE_TIMER', så må enten 'ukedager' eller 'enkeltdager' være satt.",
+                      "invalid_value": "enkeltdager = null, ukedager = null"
                     }
                   ]
                 }
@@ -1574,9 +1573,9 @@ class ApplicationTest {
                   "invalid_parameters": [
                     {
                       "type": "entity",
-                      "name": "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltDager",
-                      "reason": "Dersom vetOmsorgstilbud er 'VET_IKKE', så kan verken 'ukedager' eller 'enkeltDager' være satt.",
-                      "invalid_value": "enkeltDager = null, ukedager = OmsorgstilbudUkedager(mandag=PT7H, tirsdag=null, onsdag=null, torsdag=null, fredag=null)"
+                      "name": "omsorgstilbudV2.planlagt.ukedager eller omsorgstilbudV2.planlagt.enkeltdager",
+                      "reason": "Dersom vetOmsorgstilbud er 'VET_IKKE', så kan verken 'ukedager' eller 'enkeltdager' være satt.",
+                      "invalid_value": "enkeltdager = null, ukedager = OmsorgstilbudUkedager(mandag=PT7H, tirsdag=null, onsdag=null, torsdag=null, fredag=null)"
                     }
                   ]
                 }
@@ -1697,9 +1696,9 @@ class ApplicationTest {
                   "invalid_parameters": [
                     {
                       "type": "entity",
-                      "name": "omsorgstilbudV2.historisk.enkeltDager",
+                      "name": "omsorgstilbudV2.historisk.enkeltdager",
                       "reason": "Historiske enkeltdager inneholder datoer som er enten lik eller senere enn dagens dato.",
-                      "invalid_value": "enkeltDager = [OmsorgstilbudEnkeltDag(dato=${LocalDate.now()}, tid=PT7H)]"
+                      "invalid_value": "enkeltdager = [OmsorgstilbudEnkeltDag(dato=${LocalDate.now()}, tid=PT7H)]"
                     }
                   ]
                 }
@@ -1710,7 +1709,7 @@ class ApplicationTest {
                 .defaultSøknad(UUID.randomUUID().toString()).copy(
                     omsorgstilbudV2 = OmsorgstilbudV2(
                         historisk = HistoriskOmsorgstilbud(
-                            enkeltDager = listOf(
+                            enkeltdager = listOf(
                                 OmsorgstilbudEnkeltDag(dato = LocalDate.now(), tid = Duration.ofHours(7))
                             ),
                         )

--- a/src/test/kotlin/no/nav/helse/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/helse/SerDesTest.kt
@@ -2,7 +2,35 @@ package no.nav.helse
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.helse.soker.Søker
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.Arbeidsforhold
+import no.nav.helse.soknad.Arbeidsform
+import no.nav.helse.soknad.ArbeidsgiverDetaljer
+import no.nav.helse.soknad.BarnDetaljer
+import no.nav.helse.soknad.Beredskap
+import no.nav.helse.soknad.Bosted
+import no.nav.helse.soknad.Ferieuttak
+import no.nav.helse.soknad.FerieuttakIPerioden
+import no.nav.helse.soknad.Frilans
+import no.nav.helse.soknad.KomplettSøknad
+import no.nav.helse.soknad.Land
+import no.nav.helse.soknad.Medlemskap
+import no.nav.helse.soknad.Nattevåk
+import no.nav.helse.soknad.Næringstyper
+import no.nav.helse.soknad.Omsorgstilbud
+import no.nav.helse.soknad.OmsorgstilbudUkedager
+import no.nav.helse.soknad.OrganisasjonDetaljer
+import no.nav.helse.soknad.Periode
+import no.nav.helse.soknad.Regnskapsfører
+import no.nav.helse.soknad.SkalJobbe
+import no.nav.helse.soknad.Språk
+import no.nav.helse.soknad.Søknad
+import no.nav.helse.soknad.Utenlandsopphold
+import no.nav.helse.soknad.UtenlandsoppholdIPerioden
+import no.nav.helse.soknad.VarigEndring
+import no.nav.helse.soknad.VetOmsorgstilbud
+import no.nav.helse.soknad.Virksomhet
+import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
+import no.nav.helse.soknad.Årsak
 import no.nav.helse.vedlegg.DokumentEier
 import no.nav.helse.vedlegg.Vedlegg
 import org.junit.Test
@@ -675,7 +703,7 @@ internal class SerDesTest {
             ),
             skalPassePåBarnetIHelePerioden = true,
             omsorgstilbud = Omsorgstilbud(
-                fasteDager = OmsorgstilbudFasteDager(
+                fasteDager = OmsorgstilbudUkedager(
                     mandag = Duration.ofHours(1),
                     tirsdag = Duration.ofHours(1),
                     onsdag = Duration.ofHours(1),

--- a/src/test/kotlin/no/nav/helse/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/helse/SøknadUtils.kt
@@ -4,7 +4,35 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.helse.dusseldorf.ktor.jackson.dusseldorfConfigured
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.Arbeidsforhold
+import no.nav.helse.soknad.Arbeidsform
+import no.nav.helse.soknad.ArbeidsgiverDetaljer
+import no.nav.helse.soknad.BarnDetaljer
+import no.nav.helse.soknad.BarnRelasjon
+import no.nav.helse.soknad.Bosted
+import no.nav.helse.soknad.Ferieuttak
+import no.nav.helse.soknad.FerieuttakIPerioden
+import no.nav.helse.soknad.Frilans
+import no.nav.helse.soknad.Land
+import no.nav.helse.soknad.Medlemskap
+import no.nav.helse.soknad.Næringstyper
+import no.nav.helse.soknad.Omsorgstilbud
+import no.nav.helse.soknad.OmsorgstilbudUkedager
+import no.nav.helse.soknad.OmsorgstilbudV2
+import no.nav.helse.soknad.OrganisasjonDetaljer
+import no.nav.helse.soknad.Periode
+import no.nav.helse.soknad.PlanlagtOmsorgstilbud
+import no.nav.helse.soknad.Regnskapsfører
+import no.nav.helse.soknad.SkalJobbe
+import no.nav.helse.soknad.Språk
+import no.nav.helse.soknad.Søknad
+import no.nav.helse.soknad.Utenlandsopphold
+import no.nav.helse.soknad.UtenlandsoppholdIPerioden
+import no.nav.helse.soknad.VarigEndring
+import no.nav.helse.soknad.VetOmsorgstilbud
+import no.nav.helse.soknad.Virksomhet
+import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
+import no.nav.helse.soknad.Årsak
 import java.net.URL
 import java.time.Duration
 import java.time.LocalDate
@@ -366,7 +394,7 @@ class SøknadUtils {
             ),
             skalPassePåBarnetIHelePerioden = true,
             omsorgstilbud = Omsorgstilbud(
-                fasteDager = OmsorgstilbudFasteDager(
+                fasteDager = OmsorgstilbudUkedager(
                     mandag = Duration.ofHours(1),
                     tirsdag = Duration.ofHours(1),
                     onsdag = Duration.ofHours(1),
@@ -374,6 +402,18 @@ class SøknadUtils {
                     fredag = Duration.ofHours(1)
                 ),
                 vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
+            ),
+            omsorgstilbudV2 = OmsorgstilbudV2(
+                planlagt = PlanlagtOmsorgstilbud(
+                    ukedager = OmsorgstilbudUkedager(
+                        mandag = Duration.ofHours(1),
+                        tirsdag = Duration.ofHours(1),
+                        onsdag = Duration.ofHours(1),
+                        torsdag = Duration.ofHours(1),
+                        fredag = Duration.ofHours(1)
+                    ),
+                    vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
+                )
             ),
             medlemskap = Medlemskap(
                 harBoddIUtlandetSiste12Mnd = true,

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -469,7 +469,7 @@ class K9FormatTest {
     fun `gitt omsorgstilbudV2 med både historisk og planlagte omsorgsdager, forvent riktig mapping`() {
         val tilsynsordning = OmsorgstilbudV2(
             historisk = HistoriskOmsorgstilbud(
-                enkeltDager = listOf(OmsorgstilbudEnkeltDag(LocalDate.now().minusDays(1), Duration.ofHours(7)))
+                enkeltdager = listOf(OmsorgstilbudEnkeltDag(LocalDate.now().minusDays(1), Duration.ofHours(7)))
             ),
             planlagt = PlanlagtOmsorgstilbud(
                 ukedager = OmsorgstilbudUkedager(
@@ -481,16 +481,16 @@ class K9FormatTest {
                 ),
                 vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
             )
-        ).tilK9Tilsynsordning(Periode(LocalDate.now(), LocalDate.now().plusDays(10)))
+        ).tilK9Tilsynsordning(Periode(LocalDate.now(), LocalDate.now().plusDays(7)))
 
-        assertEquals(9, tilsynsordning.perioder.size)
+        assertEquals(7, tilsynsordning.perioder.size)
     }
 
     @Test
     fun `gitt omsorgstilbudV2 med både historisk og planlagte omsorgsdager der historisk har dato lik eller etter dagens dato, forvent at den blir eksludert`() {
         val tilsynsordning = OmsorgstilbudV2(
             historisk = HistoriskOmsorgstilbud(
-                enkeltDager = listOf(
+                enkeltdager = listOf(
                     OmsorgstilbudEnkeltDag(LocalDate.now().minusDays(1), Duration.ofHours(7)),
                     OmsorgstilbudEnkeltDag(LocalDate.now().minusDays(2), Duration.ofHours(7)),
                     OmsorgstilbudEnkeltDag(LocalDate.now(), Duration.ofHours(7))
@@ -508,6 +508,6 @@ class K9FormatTest {
             )
         ).tilK9Tilsynsordning(Periode(LocalDate.now(), LocalDate.now().plusDays(10)))
 
-        assertEquals(10, tilsynsordning.perioder.size)
+        assertEquals(9, tilsynsordning.perioder.size)
     }
 }

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -4,19 +4,23 @@ import no.nav.helse.SøknadUtils
 import no.nav.helse.soker.Søker
 import no.nav.helse.soknad.Arbeidsforhold
 import no.nav.helse.soknad.Arbeidsform
+import no.nav.helse.soknad.HistoriskOmsorgstilbud
 import no.nav.helse.soknad.Omsorgstilbud
-import no.nav.helse.soknad.OmsorgstilbudFasteDager
+import no.nav.helse.soknad.OmsorgstilbudEnkeltDag
+import no.nav.helse.soknad.OmsorgstilbudUkedager
+import no.nav.helse.soknad.OmsorgstilbudV2
+import no.nav.helse.soknad.PlanlagtOmsorgstilbud
 import no.nav.helse.soknad.SkalJobbe
 import no.nav.helse.soknad.VetOmsorgstilbud
 import no.nav.k9.søknad.JsonUtils
 import no.nav.k9.søknad.felles.type.Periode
-import org.junit.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import java.time.Duration
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.*
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class K9FormatTest {
@@ -202,7 +206,7 @@ class K9FormatTest {
     @Test
     fun `gitt søknadsperiode man-fre, tilsyn alle dager, forvent 5 perioder`() {
         val k9Tilsynsordning = Omsorgstilbud(
-            fasteDager = OmsorgstilbudFasteDager(
+            fasteDager = OmsorgstilbudUkedager(
                 mandag = Duration.ofHours(5),
                 tirsdag = Duration.ofHours(5),
                 onsdag = Duration.ofHours(5),
@@ -237,13 +241,14 @@ class K9FormatTest {
               },
               "perioderSomSkalSlettes": {}
             }
-        """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true)
+        """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true
+        )
     }
 
     @Test
     fun `gitt søknadsperiode ons-man, tilsyn alle dager, forvent 4 perioder med lør-søn ekskludert`() {
         val k9Tilsynsordning = Omsorgstilbud(
-            fasteDager = OmsorgstilbudFasteDager(
+            fasteDager = OmsorgstilbudUkedager(
                 mandag = Duration.ofHours(5),
                 tirsdag = Duration.ofHours(5),
                 onsdag = Duration.ofHours(5),
@@ -282,7 +287,7 @@ class K9FormatTest {
     @Test
     fun `gitt søknadsperiode man-fre, tilsyn man-ons og fre, forvent 4 perioder`() {
         val k9Tilsynsordning = Omsorgstilbud(
-            fasteDager = OmsorgstilbudFasteDager(
+            fasteDager = OmsorgstilbudUkedager(
                 mandag = Duration.ofHours(5),
                 tirsdag = Duration.ofHours(5),
                 onsdag = Duration.ofHours(5),
@@ -320,7 +325,8 @@ class K9FormatTest {
 
     @Test
     fun `gitt søknadsperiode man-fre, uten tilsyn, forvent 1 periode med 0 timer`() {
-        val k9Tilsynsordning = tilK9Tilsynsordning0Timer(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+        val k9Tilsynsordning =
+            tilK9Tilsynsordning0Timer(Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
 
         assertEquals(1, k9Tilsynsordning.perioder.size)
 
@@ -342,7 +348,7 @@ class K9FormatTest {
     @Test
     fun `gitt søknadsperiode man-fre, tilsyn 10t alle dager, forvent 5 perioder med 7t 30m`() {
         val k9Tilsynsordning = Omsorgstilbud(
-            fasteDager = OmsorgstilbudFasteDager(
+            fasteDager = OmsorgstilbudUkedager(
                 mandag = Duration.ofHours(10),
                 tirsdag = Duration.ofHours(10),
                 onsdag = Duration.ofHours(10),
@@ -457,5 +463,51 @@ class K9FormatTest {
             }
         """.trimIndent(), JsonUtils.toString(arbeidstidInfo), true
         )
+    }
+
+    @Test
+    fun `gitt omsorgstilbudV2 med både historisk og planlagte omsorgsdager, forvent riktig mapping`() {
+        val tilsynsordning = OmsorgstilbudV2(
+            historisk = HistoriskOmsorgstilbud(
+                enkeltDager = listOf(OmsorgstilbudEnkeltDag(LocalDate.now().minusDays(1), Duration.ofHours(7)))
+            ),
+            planlagt = PlanlagtOmsorgstilbud(
+                ukedager = OmsorgstilbudUkedager(
+                    mandag = Duration.ofHours(1),
+                    tirsdag = Duration.ofHours(1),
+                    onsdag = Duration.ofHours(1),
+                    torsdag = Duration.ofHours(1),
+                    fredag = Duration.ofHours(1)
+                ),
+                vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
+            )
+        ).tilK9Tilsynsordning(Periode(LocalDate.now(), LocalDate.now().plusDays(10)))
+
+        assertEquals(9, tilsynsordning.perioder.size)
+    }
+
+    @Test
+    fun `gitt omsorgstilbudV2 med både historisk og planlagte omsorgsdager der historisk har dato lik eller etter dagens dato, forvent at den blir eksludert`() {
+        val tilsynsordning = OmsorgstilbudV2(
+            historisk = HistoriskOmsorgstilbud(
+                enkeltDager = listOf(
+                    OmsorgstilbudEnkeltDag(LocalDate.now().minusDays(1), Duration.ofHours(7)),
+                    OmsorgstilbudEnkeltDag(LocalDate.now().minusDays(2), Duration.ofHours(7)),
+                    OmsorgstilbudEnkeltDag(LocalDate.now(), Duration.ofHours(7))
+                )
+            ),
+            planlagt = PlanlagtOmsorgstilbud(
+                ukedager = OmsorgstilbudUkedager(
+                    mandag = Duration.ofHours(1),
+                    tirsdag = Duration.ofHours(1),
+                    onsdag = Duration.ofHours(1),
+                    torsdag = Duration.ofHours(1),
+                    fredag = Duration.ofHours(1)
+                ),
+                vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
+            )
+        ).tilK9Tilsynsordning(Periode(LocalDate.now(), LocalDate.now().plusDays(10)))
+
+        assertEquals(10, tilsynsordning.perioder.size)
     }
 }


### PR DESCRIPTION
- Validerer historiske enkeltDager.
Historiske enkeltDager som inneholder datoer lik eller senere enn dagens dato gir feil.

- fasteDager (nå ukedager i v2) har samme valideringsmekanisme som før.

- Både historiske og planlagte omsorgsdager er tillatt.
Historiske datoer blir mappet med egne datoer som før.
Ukerdager (planlagt) blir mappet fra dagens dato fram til søknadenperiodens tilOgMed dato.

- Legger til validering og mapping tester av nytt format.

- Markerer gammel struktur som utgått.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>