### PR TITLE
Øker tiden søknad er mellomlagret fra 24t til 72t.

### DIFF
--- a/src/main/kotlin/no/nav/helse/App.kt
+++ b/src/main/kotlin/no/nav/helse/App.kt
@@ -26,7 +26,14 @@ import no.nav.helse.dusseldorf.ktor.auth.multipleJwtIssuers
 import no.nav.helse.dusseldorf.ktor.client.HttpRequestHealthCheck
 import no.nav.helse.dusseldorf.ktor.client.HttpRequestHealthConfig
 import no.nav.helse.dusseldorf.ktor.client.buildURL
-import no.nav.helse.dusseldorf.ktor.core.*
+import no.nav.helse.dusseldorf.ktor.core.DefaultProbeRoutes
+import no.nav.helse.dusseldorf.ktor.core.DefaultStatusPages
+import no.nav.helse.dusseldorf.ktor.core.correlationIdAndRequestIdInMdc
+import no.nav.helse.dusseldorf.ktor.core.generated
+import no.nav.helse.dusseldorf.ktor.core.id
+import no.nav.helse.dusseldorf.ktor.core.log
+import no.nav.helse.dusseldorf.ktor.core.logProxyProperties
+import no.nav.helse.dusseldorf.ktor.core.logRequests
 import no.nav.helse.dusseldorf.ktor.health.HealthReporter
 import no.nav.helse.dusseldorf.ktor.health.HealthRoute
 import no.nav.helse.dusseldorf.ktor.health.HealthService
@@ -149,7 +156,8 @@ fun Application.pleiepengesoknadapi() {
 
             mellomlagringApis(
                 mellomlagringService = MellomlagringService(
-                    RedisStore(
+                    søknadMellomlagretTidTimer = configuration.getSoknadMellomlagringTidTimer(),
+                    redisStore = RedisStore(
                         redisClient = RedisConfig.redisClient(
                             redisHost = configuration.getRedisHost(),
                             redisPort = configuration.getRedisPort()

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -37,6 +37,8 @@ data class Configuration(val config: ApplicationConfig) {
         )
     }
 
+    internal fun getSoknadMellomlagringTidTimer() = config.getRequiredString("nav.mellomlagring.tid_timer", false)
+
     internal fun getK9OppslagUrl() = URI(config.getRequiredString("nav.gateways.k9_oppslag_url", secret = false))
 
     internal fun getK9MellomlagringUrl() = URI(config.getRequiredString("nav.gateways.k9_mellomlagring_url", secret = false))

--- a/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
+++ b/src/main/kotlin/no/nav/helse/mellomlagring/MellomlagringService.kt
@@ -5,9 +5,10 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.*
 
-class MellomlagringService constructor(
+class MellomlagringService(
     private val redisStore: RedisStore,
-    private val passphrase: String
+    private val passphrase: String,
+    private val søknadMellomlagretTidTimer: String
 ) {
     private companion object {
         private val log: Logger = LoggerFactory.getLogger(MellomlagringService::class.java)
@@ -27,7 +28,7 @@ class MellomlagringService constructor(
         fnr: String,
         midlertidigSøknad: String,
         expirationDate: Date = Calendar.getInstance().let {
-            it.add(Calendar.HOUR, 24)
+            it.add(Calendar.HOUR, søknadMellomlagretTidTimer.toInt())
             it.time
         }
     ) {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,6 +63,9 @@ nav {
         passphrase=""
         passphrase=${?STORAGE_PASSPHRASE}
     }
+    mellomlagring {
+        tid_timer = "72"
+    }
     cache{
         barn{
             expiry_in_minutes = "30"

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -52,6 +52,8 @@ object TestConfiguration {
         map["nav.redis.port"] = "${redisServer.bindPort}"
         map["nav.storage.passphrase"] = "verySecret"
 
+        map["nav.mellomlagring.tid_timer"] = "1"
+
         return map.toMap()
     }
 }

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -516,7 +516,7 @@ class K9FormatTest {
                 ),
                 vetOmsorgstilbud = VetOmsorgstilbud.VET_ALLE_TIMER
             )
-        ).tilK9Tilsynsordning(Periode(LocalDate.parse("2021-09-03"), LocalDate.parse("2021-09-13")))
+        ).tilK9Tilsynsordning(Periode(LocalDate.parse("2021-09-03"), LocalDate.parse("2021-09-13")), LocalDate.parse("2021-09-03"))
 
         assertEquals(9, tilsynsordning.perioder.size)
     }

--- a/src/test/kotlin/no/nav/helse/mellomlagring/MellomlagringTest.kt
+++ b/src/test/kotlin/no/nav/helse/mellomlagring/MellomlagringTest.kt
@@ -9,7 +9,11 @@ import org.awaitility.Durations.ONE_SECOND
 import org.junit.AfterClass
 import org.slf4j.LoggerFactory
 import java.util.*
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @KtorExperimentalAPI
 class MellomlagringTest {
@@ -33,7 +37,8 @@ class MellomlagringTest {
 
         val mellomlagringService = MellomlagringService(
             redisStore,
-            "VerySecretPass"
+            "VerySecretPass",
+            "1"
         )
 
         @AfterClass


### PR DESCRIPTION
- Refaktorer ut tiden søknad er mellomlagret som config.
- Fikser test.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>