### PR TITLE
Fjerne arbeidsform

### DIFF
--- a/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
@@ -159,7 +159,7 @@ enum class Årsak {
 }
 
 data class Arbeidsforhold(
-    val arbeidsform: Arbeidsform,
+    val arbeidsform: Arbeidsform? = null, // Feltet skal bort. Settes som nullable for å støtte begge versjoner.
     val jobberNormaltTimer: Double,
     val historiskArbeid: ArbeidIPeriode? = null,
     val planlagtArbeid: ArbeidIPeriode? = null


### PR DESCRIPTION
Setter arbeidsform som nullable. Skal fjernes men må støtte begge versjoner i overgangen.