### PR TITLE
Oppgraderer k9-format til 5.5.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,12 @@
 version: 2
+
+registries:
+  k9-format:
+    type: maven-repository
+    url: https://maven.pkg.github.com/navikt/k9-format
+    username: x-access-token
+    password: ${{secrets.READER_TOKEN}}
+
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -10,3 +18,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    registries:
+      - k9-format

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ registries:
     url: https://maven.pkg.github.com/navikt/k9-format
     username: x-access-token
     password: ${{secrets.READER_TOKEN}}
+  dusseldorf-ktor:
+    type: maven-repository
+    url: https://maven.pkg.github.com/navikt/dusseldorf-ktor
+    username: x-access-token
+    password: ${{secrets.READER_TOKEN}}
 
 updates:
   - package-ecosystem: github-actions
@@ -20,3 +25,4 @@ updates:
       interval: daily
     registries:
       - k9-format
+      - dusseldorf-ktor

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val dusseldorfKtorVersion = "3.1.6.4-e07c5ec"
 val ktorVersion = ext.get("ktorVersion").toString()
-val k9FormatVersion = "5.5.10"
+val k9FormatVersion = "5.5.12"
 val mainClass = "no.nav.helse.AppKt"
 
 val fuelVersion = "2.3.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val dusseldorfKtorVersion = "3.1.6.4-e07c5ec"
 val ktorVersion = ext.get("ktorVersion").toString()
-val k9FormatVersion = "5.4.25"
+val k9FormatVersion = "5.5.10"
 val mainClass = "no.nav.helse.AppKt"
 
 val fuelVersion = "2.3.1"

--- a/src/main/kotlin/no/nav/helse/k9format/K9Arbeidstid.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9Arbeidstid.kt
@@ -1,7 +1,13 @@
 package no.nav.helse.k9format
 
-import no.nav.helse.soknad.*
-import no.nav.helse.soknad.JobberIPeriodeSvar.*
+import no.nav.helse.soknad.ArbeidIPeriode
+import no.nav.helse.soknad.Arbeidsforhold
+import no.nav.helse.soknad.ArbeidsforholdAnsatt
+import no.nav.helse.soknad.JobberIPeriodeSvar.JA
+import no.nav.helse.soknad.JobberIPeriodeSvar.NEI
+import no.nav.helse.soknad.JobberIPeriodeSvar.VET_IKKE
+import no.nav.helse.soknad.PlanUkedager
+import no.nav.helse.soknad.Søknad
 import no.nav.k9.søknad.felles.type.Organisasjonsnummer
 import no.nav.k9.søknad.felles.type.Periode
 import no.nav.k9.søknad.ytelse.psb.v1.arbeidstid.Arbeidstaker
@@ -52,7 +58,7 @@ fun Arbeidsforhold?.beregnK9ArbeidstidInfo(søknadsperiode: Periode, dagensDato:
         )
     )
 
-    val arbeidstidInfo = ArbeidstidInfo().medPerioder(null)
+    val arbeidstidInfo = ArbeidstidInfo()
     val normalTimerPerDag = jobberNormaltTimer.tilTimerPerDag().tilDuration()
     val gårsdagensDato = dagensDato.minusDays(1)
 

--- a/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
@@ -70,14 +70,7 @@ fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker, dagensDato: Loca
 
 fun Søker.tilK9Søker(): K9Søker = K9Søker(NorskIdentitetsnummer.of(fødselsnummer))
 
-fun BarnDetaljer.tilK9Barn(): K9Barn {
-    val k9Barn = K9Barn()
-    when {
-        fødselsnummer != null -> k9Barn.medNorskIdentitetsnummer(NorskIdentitetsnummer.of(fødselsnummer))
-        fødselsdato != null -> k9Barn.medFødselsdato(fødselsdato)
-    }
-    return k9Barn
-}
+fun BarnDetaljer.tilK9Barn(): K9Barn = K9Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of(fødselsnummer!!))
 
 fun Søknad.byggK9DataBruktTilUtledning(): DataBruktTilUtledning = DataBruktTilUtledning(
     harForståttRettigheterOgPlikter,

--- a/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9Format.kt
@@ -13,9 +13,13 @@ import no.nav.k9.søknad.felles.type.Landkode
 import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer
 import no.nav.k9.søknad.felles.type.Periode
 import no.nav.k9.søknad.felles.type.SøknadId
-import no.nav.k9.søknad.ytelse.psb.v1.*
 import no.nav.k9.søknad.ytelse.psb.v1.Beredskap.BeredskapPeriodeInfo
+import no.nav.k9.søknad.ytelse.psb.v1.DataBruktTilUtledning
+import no.nav.k9.søknad.ytelse.psb.v1.LovbestemtFerie
 import no.nav.k9.søknad.ytelse.psb.v1.Nattevåk.NattevåkPeriodeInfo
+import no.nav.k9.søknad.ytelse.psb.v1.Omsorg
+import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn
+import no.nav.k9.søknad.ytelse.psb.v1.Uttak
 import no.nav.k9.søknad.ytelse.psb.v1.tilsyn.TilsynPeriodeInfo
 import java.time.DayOfWeek
 import java.time.Duration
@@ -66,7 +70,14 @@ fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker, dagensDato: Loca
 
 fun Søker.tilK9Søker(): K9Søker = K9Søker(NorskIdentitetsnummer.of(fødselsnummer))
 
-fun BarnDetaljer.tilK9Barn(): K9Barn = K9Barn(NorskIdentitetsnummer.of(fødselsnummer), (fødselsdato))
+fun BarnDetaljer.tilK9Barn(): K9Barn {
+    val k9Barn = K9Barn()
+    when {
+        fødselsnummer != null -> k9Barn.medNorskIdentitetsnummer(NorskIdentitetsnummer.of(fødselsnummer))
+        fødselsdato != null -> k9Barn.medFødselsdato(fødselsdato)
+    }
+    return k9Barn
+}
 
 fun Søknad.byggK9DataBruktTilUtledning(): DataBruktTilUtledning = DataBruktTilUtledning(
     harForståttRettigheterOgPlikter,
@@ -115,55 +126,56 @@ fun tilK9Tilsynsordning0Timer(periode: Periode) = K9Tilsynsordning().apply {
     )
 }
 
-fun Omsorgstilbud.tilK9Tilsynsordning(periode: Periode, dagensDato: LocalDate = LocalDate.now()): K9Tilsynsordning = K9Tilsynsordning().apply {
+fun Omsorgstilbud.tilK9Tilsynsordning(periode: Periode, dagensDato: LocalDate = LocalDate.now()): K9Tilsynsordning =
+    K9Tilsynsordning().apply {
 
-    if (historisk == null && planlagt == null) return tilK9Tilsynsordning0Timer(periode)
+        if (historisk == null && planlagt == null) return tilK9Tilsynsordning0Timer(periode)
 
-    historisk?.enkeltdager?.map {
-        leggeTilPeriode(
-            Periode(it.dato, it.dato),
-            TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(
-                Duration.ZERO.plusOmIkkeNullOgAvkortTilNormalArbeidsdag(it.tid)
+        historisk?.enkeltdager?.map {
+            leggeTilPeriode(
+                Periode(it.dato, it.dato),
+                TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(
+                    Duration.ZERO.plusOmIkkeNullOgAvkortTilNormalArbeidsdag(it.tid)
+                )
             )
-        )
-    }
+        }
 
-    planlagt?.ukedager?.apply {
-        val periodeStart = if(dagensDato.isBefore(periode.fraOgMed)) periode.fraOgMed else dagensDato
-        periodeStart.datesUntil(periode.tilOgMed.plusDays(1)).toList()
-            .map { dato: LocalDate ->
-                when (dato.dayOfWeek) {
-                    DayOfWeek.MONDAY -> mandag
-                    DayOfWeek.TUESDAY -> tirsdag
-                    DayOfWeek.WEDNESDAY -> onsdag
-                    DayOfWeek.THURSDAY -> torsdag
-                    DayOfWeek.FRIDAY -> fredag
-                    else -> null
-                }?.let { tilsynLengde: Duration ->
-                    leggeTilPeriode(
-                        Periode(dato, dato),
-                        TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(
-                            Duration.ZERO.plusOmIkkeNullOgAvkortTilNormalArbeidsdag(tilsynLengde)
+        planlagt?.ukedager?.apply {
+            val periodeStart = if (dagensDato.isBefore(periode.fraOgMed)) periode.fraOgMed else dagensDato
+            periodeStart.datesUntil(periode.tilOgMed.plusDays(1)).toList()
+                .map { dato: LocalDate ->
+                    when (dato.dayOfWeek) {
+                        DayOfWeek.MONDAY -> mandag
+                        DayOfWeek.TUESDAY -> tirsdag
+                        DayOfWeek.WEDNESDAY -> onsdag
+                        DayOfWeek.THURSDAY -> torsdag
+                        DayOfWeek.FRIDAY -> fredag
+                        else -> null
+                    }?.let { tilsynLengde: Duration ->
+                        leggeTilPeriode(
+                            Periode(dato, dato),
+                            TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(
+                                Duration.ZERO.plusOmIkkeNullOgAvkortTilNormalArbeidsdag(tilsynLengde)
+                            )
                         )
-                    )
+                    }
                 }
-            }
-    }
+        }
 
-    planlagt?.enkeltdager?.map {
-        leggeTilPeriode(
-            Periode(it.dato, it.dato),
-            TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(
-                Duration.ZERO.plusOmIkkeNullOgAvkortTilNormalArbeidsdag(it.tid)
+        planlagt?.enkeltdager?.map {
+            leggeTilPeriode(
+                Periode(it.dato, it.dato),
+                TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(
+                    Duration.ZERO.plusOmIkkeNullOgAvkortTilNormalArbeidsdag(it.tid)
+                )
             )
-        )
+        }
     }
-}
 
 fun Søknad.byggK9Uttak(periode: Periode): Uttak? {
-    val perioder = mutableMapOf<Periode, UttakPeriodeInfo>()
+    val perioder = mutableMapOf<Periode, Uttak.UttakPeriodeInfo>()
 
-    perioder[periode] = UttakPeriodeInfo(Duration.ofHours(7).plusMinutes(30))
+    perioder[periode] = Uttak.UttakPeriodeInfo(Duration.ofHours(7).plusMinutes(30))
 
     return Uttak().medPerioder(perioder)
 }
@@ -184,7 +196,7 @@ fun Medlemskap.tilK9Bosteder(): Bosteder? {
     val perioder = mutableMapOf<Periode, Bosteder.BostedPeriodeInfo>()
 
     utenlandsoppholdSiste12Mnd.forEach { bosted ->
-        if (!bosted.landkode.isNullOrEmpty()) perioder[Periode(bosted.fraOgMed, bosted.tilOgMed)] =
+        if (!bosted.landkode.isEmpty()) perioder[Periode(bosted.fraOgMed, bosted.tilOgMed)] =
             Bosteder.BostedPeriodeInfo()
                 .medLand(Landkode.of(bosted.landkode))
     }

--- a/src/main/kotlin/no/nav/helse/k9format/K9OpptjeningAktivitet.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9OpptjeningAktivitet.kt
@@ -18,16 +18,19 @@ fun Double.tilFaktiskTimerPerUke(prosent: Double) = this.times(prosent.div(100))
 fun Double.tilTimerPerDag() = this.div(DAGER_PER_UKE)
 fun Double.tilDuration() = Duration.ofMinutes((this * 60).toLong())
 
-internal fun Søknad.byggK9OpptjeningAktivitet() = OpptjeningAktivitet(
-    selvstendigNæringsdrivende?.tilK9SelvstendigNæringsdrivende(),
-    frilans?.tilK9Frilanser(),
-    null,
-    null
-)
+internal fun Søknad.byggK9OpptjeningAktivitet(): OpptjeningAktivitet {
+    val opptjeningAktivitet = OpptjeningAktivitet()
+    selvstendigNæringsdrivende?.let { opptjeningAktivitet.medSelvstendigNæringsdrivende(it.tilK9SelvstendigNæringsdrivende()) }
+    frilans?.let { opptjeningAktivitet.medFrilanser(it.tilK9Frilanser()) }
+    return opptjeningAktivitet
+}
 
-internal fun Frilans.tilK9Frilanser(): Frilanser = Frilanser()
-    .medStartDato(startdato)
-    .medSluttDato(sluttdato)
+internal fun Frilans.tilK9Frilanser(): Frilanser {
+    val frilanser = Frilanser()
+    frilanser.medStartDato(startdato)
+    sluttdato?.let { frilanser.medSluttDato(it) }
+    return frilanser
+}
 
 fun no.nav.helse.soknad.SelvstendigNæringsdrivende.tilK9SelvstendigNæringsdrivende(): List<SelvstendigNæringsdrivende> {
 

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -6,7 +6,7 @@ import no.nav.helse.dusseldorf.ktor.core.ValidationProblemDetails
 import no.nav.helse.dusseldorf.ktor.core.Violation
 import no.nav.helse.soknad.validering.valider
 import no.nav.helse.utils.erLikEllerEtterDagensDato
-import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn
+import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarnSøknadValidator
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -229,7 +229,7 @@ internal fun Søknad.validate(k9FormatSøknad: no.nav.k9.søknad.Søknad) {
 
 private fun validerK9Format(k9FormatSøknad: no.nav.k9.søknad.Søknad): MutableSet<Violation> {
 
-    return PleiepengerSyktBarn().validator.valider(k9FormatSøknad.getYtelse<PleiepengerSyktBarn>()).map {
+    return PleiepengerSyktBarnSøknadValidator().valider(k9FormatSøknad).map {
         Violation(
             parameterName = it.felt,
             parameterType = ParameterType.ENTITY,

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -9,8 +9,30 @@ import io.ktor.server.testing.*
 import no.nav.helse.dusseldorf.ktor.core.fromResources
 import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.helse.mellomlagring.started
-import no.nav.helse.soknad.*
-import no.nav.helse.wiremock.*
+import no.nav.helse.soknad.ArbeidIPeriode
+import no.nav.helse.soknad.Arbeidsforhold
+import no.nav.helse.soknad.BarnDetaljer
+import no.nav.helse.soknad.Enkeltdag
+import no.nav.helse.soknad.Ferieuttak
+import no.nav.helse.soknad.FerieuttakIPerioden
+import no.nav.helse.soknad.HistoriskOmsorgstilbud
+import no.nav.helse.soknad.JobberIPeriodeSvar
+import no.nav.helse.soknad.Næringstyper
+import no.nav.helse.soknad.Omsorgstilbud
+import no.nav.helse.soknad.PlanlagtOmsorgstilbud
+import no.nav.helse.soknad.Regnskapsfører
+import no.nav.helse.soknad.SelvstendigNæringsdrivende
+import no.nav.helse.soknad.Virksomhet
+import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
+import no.nav.helse.wiremock.pleiepengesoknadApiConfig
+import no.nav.helse.wiremock.stubK9Mellomlagring
+import no.nav.helse.wiremock.stubK9MellomlagringHealth
+import no.nav.helse.wiremock.stubK9OppslagArbeidsgivere
+import no.nav.helse.wiremock.stubK9OppslagBarn
+import no.nav.helse.wiremock.stubK9OppslagSoker
+import no.nav.helse.wiremock.stubLeggSoknadTilProsessering
+import no.nav.helse.wiremock.stubOppslagHealth
+import no.nav.helse.wiremock.stubPleiepengesoknadMottakHealth
 import org.json.JSONObject
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -621,7 +643,7 @@ class ApplicationTest {
                         næringsinntekt = 123123,
                         navnPåVirksomheten = "TullOgTøys",
                         registrertINorge = true,
-                        organisasjonsnummer = "101010",
+                        organisasjonsnummer = "926032925",
                         yrkesaktivSisteTreFerdigliknedeÅrene = YrkesaktivSisteTreFerdigliknedeÅrene(LocalDate.now()),
                         regnskapsfører = Regnskapsfører(
                             navn = "Kjell",
@@ -672,6 +694,18 @@ class ApplicationTest {
                   "name": "selvstendingNæringsdrivende.virksomhet.registrertIUtlandet",
                   "reason": "Hvis registrertINorge er false må registrertIUtlandet være satt",
                   "invalid_value": null
+                },
+                {
+                  "type": "entity",
+                  "name": "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].perioder[2021-02-07/2021-02-08].valideringRegistrertUtlandet",
+                  "reason": "",
+                  "invalid_value": "K9-format feilkode: Feil{felt='.landkode', feilkode='påkrevd', feilmelding='landkode må være satt, og kan ikke være null, dersom virksomhet er registrert i utlandet.'}"
+                },
+                {
+                  "type": "entity",
+                  "name": "ytelse.opptjeningAktivitet.selvstendigNæringsdrivende[0].organisasjonsnummer.valid",
+                  "reason": "Organisasjonsnummer må være gyldig.",
+                  "invalid_value": "K9-format feilkode: ugyldigOrgNummer"
                 }
               ]
             }
@@ -985,6 +1019,12 @@ class ApplicationTest {
                   "name": "ytelse.søknadsperiode.perioder[0]",
                   "reason": "Fra og med (FOM) må være før eller lik til og med (TOM).",
                   "invalid_value": "K9-format feilkode: ugyldigPeriode"
+                },
+                {
+                  "type": "entity",
+                  "name": "ytelse.arbeidstid.arbeidstakerList[0].organisasjonsnummer.valid",
+                  "reason": "Organisasjonsnummer må være gyldig.",
+                  "invalid_value": "K9-format feilkode: ugyldigOrgNummer"
                 }
               ]
             }

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatArbeidstidTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatArbeidstidTest.kt
@@ -1,7 +1,19 @@
 package no.nav.helse.k9format
 
 import no.nav.helse.SøknadUtils
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.ArbeidIPeriode
+import no.nav.helse.soknad.Arbeidsforhold
+import no.nav.helse.soknad.ArbeidsforholdAnsatt
+import no.nav.helse.soknad.Enkeltdag
+import no.nav.helse.soknad.Frilans
+import no.nav.helse.soknad.JobberIPeriodeSvar
+import no.nav.helse.soknad.Næringstyper
+import no.nav.helse.soknad.PlanUkedager
+import no.nav.helse.soknad.Regnskapsfører
+import no.nav.helse.soknad.SelvstendigNæringsdrivende
+import no.nav.helse.soknad.Virksomhet
+import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
+import no.nav.helse.soknad.validate
 import no.nav.helse.somJson
 import no.nav.k9.søknad.felles.type.Periode
 import org.json.JSONObject
@@ -627,7 +639,7 @@ class K9FormatArbeidstidTest {
                 næringsinntekt = 1233123,
                 navnPåVirksomheten = "TullOgTøys",
                 registrertINorge = true,
-                organisasjonsnummer = "101010",
+                organisasjonsnummer = "926032925",
                 yrkesaktivSisteTreFerdigliknedeÅrene = YrkesaktivSisteTreFerdigliknedeÅrene(LocalDate.now()),
                 regnskapsfører = Regnskapsfører(
                     navn = "Kjell",
@@ -785,7 +797,7 @@ class K9FormatArbeidstidTest {
                 fraOgMed = LocalDate.parse("2019-01-01"),
                 navnPåVirksomheten = "TullOgTøys",
                 registrertINorge = true,
-                organisasjonsnummer = "101010",
+                organisasjonsnummer = "926032925",
                 yrkesaktivSisteTreFerdigliknedeÅrene = YrkesaktivSisteTreFerdigliknedeÅrene(LocalDate.now()),
                 regnskapsfører = Regnskapsfører(
                     navn = "Kjell",
@@ -888,7 +900,7 @@ class K9FormatArbeidstidTest {
                 fraOgMed = LocalDate.parse("2019-01-01"),
                 navnPåVirksomheten = "TullOgTøys",
                 registrertINorge = true,
-                organisasjonsnummer = "101010",
+                organisasjonsnummer = "926032925",
                 yrkesaktivSisteTreFerdigliknedeÅrene = YrkesaktivSisteTreFerdigliknedeÅrene(LocalDate.now()),
                 regnskapsfører = Regnskapsfører(
                     navn = "Kjell",

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -2,7 +2,13 @@ package no.nav.helse.k9format
 
 import no.nav.helse.SøknadUtils
 import no.nav.helse.soker.Søker
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.Enkeltdag
+import no.nav.helse.soknad.Ferieuttak
+import no.nav.helse.soknad.FerieuttakIPerioden
+import no.nav.helse.soknad.HistoriskOmsorgstilbud
+import no.nav.helse.soknad.Omsorgstilbud
+import no.nav.helse.soknad.PlanUkedager
+import no.nav.helse.soknad.PlanlagtOmsorgstilbud
 import no.nav.k9.søknad.JsonUtils
 import no.nav.k9.søknad.felles.type.Periode
 import org.skyscreamer.jsonassert.JSONAssert
@@ -67,7 +73,7 @@ class K9FormatTest {
                 "type": "PLEIEPENGER_SYKT_BARN",
                 "barn": {
                   "norskIdentitetsnummer": "03028104560",
-                  "fødselsdato": "2018-01-01"
+                  "fødselsdato": null
                 },
                 "søknadsperiode": [
                   "2021-01-01/2021-01-10"
@@ -151,8 +157,7 @@ class K9FormatTest {
                     "2021-01-02/2021-01-02": {
                       "etablertTilsynTimerPerDag": "PT5H"
                     }
-                  },
-                  "perioderSomSkalSlettes": {}
+                  }
                 },
                 "lovbestemtFerie": {
                   "perioder": {
@@ -210,8 +215,7 @@ class K9FormatTest {
                     "2021-01-01/2021-01-10": {
                       "timerPleieAvBarnetPerDag": "PT7H30M"
                     }
-                  },
-                  "perioderSomSkalSlettes": {}
+                  }
                 },
                 "omsorg": {
                   "relasjonTilBarnet": "ANNET",
@@ -219,7 +223,10 @@ class K9FormatTest {
                 }
               },
               "språk": "nb",
-              "journalposter": []
+              "journalposter": [],
+              "begrunnelseForInnsending": {
+                "tekst": null
+              }
             }
         """.trimIndent()
 
@@ -263,8 +270,7 @@ class K9FormatTest {
                 "2021-01-08/2021-01-08" : {
                   "etablertTilsynTimerPerDag" : "PT5H"
                 }
-              },
-              "perioderSomSkalSlettes": {}
+              }
             }
         """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true
         )
@@ -303,8 +309,7 @@ class K9FormatTest {
                 "2021-01-11/2021-01-11" : {
                   "etablertTilsynTimerPerDag" : "PT5H"
                 }
-              },
-              "perioderSomSkalSlettes": {}
+              }
             }
         """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true
         )
@@ -343,8 +348,7 @@ class K9FormatTest {
                 "2021-01-08/2021-01-08" : {
                   "etablertTilsynTimerPerDag" : "PT5H"
                 }
-              },
-              "perioderSomSkalSlettes": {}
+              }
             }
         """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true
         )
@@ -365,8 +369,7 @@ class K9FormatTest {
                 "2021-01-04/2021-01-08" : {
                   "etablertTilsynTimerPerDag" : "PT0S"
                 }
-              },
-              "perioderSomSkalSlettes": {}
+              }
             }
         """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true
         )
@@ -408,8 +411,7 @@ class K9FormatTest {
                 "2021-01-08/2021-01-08" : {
                   "etablertTilsynTimerPerDag" : "PT7H30M"
                 }
-              },
-              "perioderSomSkalSlettes": {}
+              }
             }
         """.trimIndent(), JsonUtils.toString(k9Tilsynsordning), true
         )


### PR DESCRIPTION
- Erstatter deprekerte konstruktører med setter metoder.
- Mapper kun fødselsnummer på k9Format barn, da den alltid settes.
- Legger til k9-format og dusseldorf-ktor registry i dependabot for å varsel om pakkeoppdateringer.