### PR TITLE
Fikser lesetilgang på root

### DIFF
--- a/redis-config.yml
+++ b/redis-config.yml
@@ -5,6 +5,9 @@ metadata:
     team: dusseldorf
   name: pleiepengesoknad-api-redis
   namespace: dusseldorf
+  annotations:
+    nais.io/read-only-file-system: "false"
+    nais.io/run-as-user: "999"
 spec:
   image: redis:5-alpine # or a custom Redis-image
   port: 6379


### PR DESCRIPTION
"# Failed opening the RDB file dump.rdb (in server root dir /data) for saving: Permission denied"