### PR TITLE
Refaktorerer ArbeidIPerioden.

### DIFF
--- a/src/main/kotlin/no/nav/helse/soknad/ArbeidsforholdAnsatt.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/ArbeidsforholdAnsatt.kt
@@ -16,8 +16,7 @@ data class ArbeidsforholdAnsatt(
 
 data class ArbeidIPeriode(
     val jobberIPerioden: JobberIPeriodeSvar,
-    val jobberSomVanlig: Boolean? = null,
-    @JsonAlias("_jobberProsent","jobberProsent") val jobberProsent: Double? = null,
+    @JsonAlias("_jobberProsent", "jobberProsent") val jobberProsent: Double? = null,
     val erLiktHverUke: Boolean? = null,
     val enkeltdager: List<Enkeltdag>? = null,
     val fasteDager: PlanUkedager? = null
@@ -25,8 +24,7 @@ data class ArbeidIPeriode(
 
 enum class JobberIPeriodeSvar {
     JA,
-    NEI,
-    VET_IKKE
+    NEI
 }
 
 internal fun List<ArbeidsforholdAnsatt>.validate(): MutableSet<Violation> {

--- a/src/main/kotlin/no/nav/helse/soknad/validering/ArbeidsforholdValidering.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/validering/ArbeidsforholdValidering.kt
@@ -9,8 +9,8 @@ import no.nav.helse.soknad.JobberIPeriodeSvar
 fun Arbeidsforhold.valider(path: String): MutableSet<Violation> {
     val feil = mutableSetOf<Violation>()
 
-    if(historiskArbeid != null) feil.addAll(historiskArbeid.valider("$path.arbeidsforhold.historiskArbeid"))
-    if(planlagtArbeid != null) feil.addAll(planlagtArbeid.valider("$path.arbeidsforhold.planlagtArbeid"))
+    if (historiskArbeid != null) feil.addAll(historiskArbeid.valider("$path.arbeidsforhold.historiskArbeid"))
+    if (planlagtArbeid != null) feil.addAll(planlagtArbeid.valider("$path.arbeidsforhold.planlagtArbeid"))
 
     return feil
 }
@@ -18,60 +18,73 @@ fun Arbeidsforhold.valider(path: String): MutableSet<Violation> {
 fun ArbeidIPeriode.valider(path: String): MutableSet<Violation> {
     val feil = mutableSetOf<Violation>()
 
-    if(jobberIPerioden()){
-        if(jobberSomVanlig == null){
-            feil.add(
-                Violation(
-                    parameterName = "$path.jobberSomVanlig",
-                    parameterType = ParameterType.ENTITY,
-                    reason = "Dersom jobberIPerioden=JA kan ikke jobberSomVanlig være null",
-                    invalidValue = "jobberIPerioden=$jobberSomVanlig,jobberSomVanlig=$jobberSomVanlig"
-                )
-            )
-        }
-
-        if(!jobberSomVanlig()){
-            if(enkeltdager == null && fasteDager == null){
+    when (jobberIPerioden()) {
+        true -> {
+            if (erLiktHverUke == null && enkeltdager == null) {
                 feil.add(
                     Violation(
-                        parameterName = "$path.jobberSomVanlig",
+                        parameterName = "$path.erLiktHverUke && $path.enkeltDager",
                         parameterType = ParameterType.ENTITY,
-                        reason = "Dersom jobberIPerioden=JA og jobberSomVanlig=false må enkeltdager eller faste dager være satt.",
-                        invalidValue = "jobberSomVanlig=$jobberSomVanlig,enkeltdager=$enkeltdager,fasteDager=$fasteDager"
+                        reason = "Dersom erLiktHverUke er null, må enkeltDager være satt.",
+                        invalidValue = "erLiktHverUke=$erLiktHverUke && enkeltDager=$enkeltdager"
                     )
                 )
             }
+
+            if (erLiktHverUke == true && fasteDager == null) {
+                feil.add(Violation(
+                    parameterName = "$path.erLiktHverUke && $path.fasteDager",
+                    parameterType = ParameterType.ENTITY,
+                    reason = "Dersom erLiktHverUke er true, kan ikke fasteDager være null.",
+                    invalidValue = "erLiktHverUke=$erLiktHverUke && fasteDager=$fasteDager"
+                ))
+            }
+
+            if (erLiktHverUke == false && enkeltdager == null) {
+                feil.add(Violation(
+                    parameterName = "$path.erLiktHverUke && $path.enkeltdager",
+                    parameterType = ParameterType.ENTITY,
+                    reason = "Dersom erLiktHverUke er true, kan ikke enkeltdager være null.",
+                    invalidValue = "erLiktHverUke=$erLiktHverUke && enkeltdager=$enkeltdager"
+                ))
+            }
         }
 
-        if(jobberSomVanlig()){
-            if(enkeltdager != null || fasteDager != null){
+        false -> {
+            if (enkeltdager != null) {
                 feil.add(
                     Violation(
-                        parameterName = "$path.jobberSomVanlig",
+                        parameterName = "$path.jobberIPerioden && $path.enkeltdager",
                         parameterType = ParameterType.ENTITY,
-                        reason = "Dersom jobberIPerioden=JA og jobberSomVanlig=true så kan ikke enkeltdager eller faste dager være satt.",
-                        invalidValue = "jobberSomVanlig=$jobberSomVanlig,enkeltdager=$enkeltdager,fasteDager=$fasteDager"
+                        reason = "Dersom jobberIPerioden=NEI så kan ikke enkeltdager være satt.",
+                        invalidValue = "jobberIPerioden=$jobberIPerioden && enkeltdager=$enkeltdager"
                     )
                 )
             }
-        }
-    }
-
-    if(!jobberIPerioden()){
-        if(enkeltdager != null || fasteDager != null){
-            feil.add(
-                Violation(
-                    parameterName = "$path.jobberIPerioden",
-                    parameterType = ParameterType.ENTITY,
-                    reason = "Dersom jobberIPerioden=NEI/VET_IKKE så kan ikke enkeltdager eller faste dager være satt.",
-                    invalidValue = "jobberIPerioden=$jobberIPerioden,enkeltdager=$enkeltdager,fasteDager=$fasteDager"
+            if (fasteDager != null) {
+                feil.add(
+                    Violation(
+                        parameterName = "$path.jobberIPerioden && $path.fasteDager",
+                        parameterType = ParameterType.ENTITY,
+                        reason = "Dersom jobberIPerioden=NEI så kan ikke faste dager være satt.",
+                        invalidValue = "jobberIPerioden=$jobberIPerioden && fasteDager=$fasteDager"
+                    )
                 )
-            )
+            }
+            if (erLiktHverUke != null) {
+                feil.add(
+                    Violation(
+                        parameterName = "$path.jobberIPerioden && $path.erLiktHverUke",
+                        parameterType = ParameterType.ENTITY,
+                        reason = "Dersom jobberIPerioden=NEI så kan ikke erLiktHverUke være satt.",
+                        invalidValue = "jobberIPerioden=$jobberIPerioden && erLiktHverUke=$erLiktHverUke"
+                    )
+                )
+            }
         }
     }
 
     return feil
 }
 
-fun ArbeidIPeriode.jobberIPerioden() : Boolean = this.jobberIPerioden == JobberIPeriodeSvar.JA
-fun ArbeidIPeriode.jobberSomVanlig() : Boolean = this.jobberSomVanlig != null && this.jobberSomVanlig
+fun ArbeidIPeriode.jobberIPerioden(): Boolean = this.jobberIPerioden == JobberIPeriodeSvar.JA

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -9,8 +9,31 @@ import io.ktor.server.testing.*
 import no.nav.helse.dusseldorf.ktor.core.fromResources
 import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.helse.mellomlagring.started
-import no.nav.helse.soknad.*
-import no.nav.helse.wiremock.*
+import no.nav.helse.soknad.ArbeidIPeriode
+import no.nav.helse.soknad.Arbeidsforhold
+import no.nav.helse.soknad.BarnDetaljer
+import no.nav.helse.soknad.Enkeltdag
+import no.nav.helse.soknad.Ferieuttak
+import no.nav.helse.soknad.FerieuttakIPerioden
+import no.nav.helse.soknad.HistoriskOmsorgstilbud
+import no.nav.helse.soknad.JobberIPeriodeSvar
+import no.nav.helse.soknad.Næringstyper
+import no.nav.helse.soknad.Omsorgstilbud
+import no.nav.helse.soknad.PlanlagtOmsorgstilbud
+import no.nav.helse.soknad.Regnskapsfører
+import no.nav.helse.soknad.SelvstendigNæringsdrivende
+import no.nav.helse.soknad.Virksomhet
+import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
+import no.nav.helse.wiremock.pleiepengesoknadApiConfig
+import no.nav.helse.wiremock.stubK9Mellomlagring
+import no.nav.helse.wiremock.stubK9MellomlagringHealth
+import no.nav.helse.wiremock.stubK9OppslagArbeidsgivere
+import no.nav.helse.wiremock.stubK9OppslagArbeidsgivereMedPrivate
+import no.nav.helse.wiremock.stubK9OppslagBarn
+import no.nav.helse.wiremock.stubK9OppslagSoker
+import no.nav.helse.wiremock.stubLeggSoknadTilProsessering
+import no.nav.helse.wiremock.stubOppslagHealth
+import no.nav.helse.wiremock.stubPleiepengesoknadMottakHealth
 import org.json.JSONObject
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -670,16 +693,24 @@ class ApplicationTest {
                         jobberNormaltTimer = 37.5,
                         historiskArbeid = ArbeidIPeriode(
                             jobberIPerioden = JobberIPeriodeSvar.JA,
-                            jobberSomVanlig = true,
                             erLiktHverUke = false,
-                            enkeltdager = null,
+                            enkeltdager = listOf(
+                                Enkeltdag(
+                                    dato = LocalDate.parse("2021-01-01"),
+                                    tid = Duration.ofHours(7).plusMinutes(30)
+                                )
+                            ),
                             fasteDager = null
                         ),
                         planlagtArbeid = ArbeidIPeriode(
                             jobberIPerioden = JobberIPeriodeSvar.JA,
-                            jobberSomVanlig = true,
                             erLiktHverUke = false,
-                            enkeltdager = null,
+                            enkeltdager = listOf(
+                                Enkeltdag(
+                                    dato = LocalDate.parse("2021-01-02"),
+                                    tid = Duration.ofHours(7).plusMinutes(30)
+                                )
+                            ),
                             fasteDager = null
                         )
                     )
@@ -752,15 +783,18 @@ class ApplicationTest {
                         jobberNormaltTimer = 40.0,
                         historiskArbeid = ArbeidIPeriode(
                             jobberIPerioden = JobberIPeriodeSvar.JA,
-                            jobberSomVanlig = true,
                             erLiktHverUke = false,
-                            enkeltdager = null,
+                            enkeltdager = listOf(
+                                Enkeltdag(
+                                    dato = LocalDate.parse("2021-01-01"),
+                                    tid = Duration.ofHours(7).plusMinutes(30)
+                                )
+                            ),
                             fasteDager = null
                         ),
                         planlagtArbeid = ArbeidIPeriode(
                             jobberIPerioden = JobberIPeriodeSvar.NEI,
-                            jobberSomVanlig = null,
-                            erLiktHverUke = false,
+                            erLiktHverUke = null,
                             enkeltdager = null,
                             fasteDager = null,
                             jobberProsent = 50.0

--- a/src/test/kotlin/no/nav/helse/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/helse/SerDesTest.kt
@@ -86,19 +86,29 @@ internal class SerDesTest {
                     "jobberNormaltTimer": 40.0,
                     "historiskArbeid": {
                       "jobberIPerioden": "JA",
-                      "jobberSomVanlig": true,
                       "jobberProsent": null,
                       "erLiktHverUke": true,
                       "enkeltdager": null,
-                      "fasteDager": null
+                      "fasteDager": {
+                          "mandag": "PT7H30M",
+                          "tirsdag": null,
+                          "onsdag": null,
+                          "torsdag": null,
+                          "fredag": null
+                        }
                     },
                     "planlagtArbeid": {
                       "jobberIPerioden": "JA",
-                      "jobberSomVanlig": true,
                       "jobberProsent": null,
                       "erLiktHverUke": true,
                       "enkeltdager": null,
-                      "fasteDager": null
+                      "fasteDager": {
+                          "mandag": "PT7H30M",
+                          "tirsdag": null,
+                          "onsdag": null,
+                          "torsdag": null,
+                          "fredag": null
+                        }
                     }
                   }
                 },
@@ -167,19 +177,29 @@ internal class SerDesTest {
                   "jobberNormaltTimer": 40.0,
                   "historiskArbeid": {
                     "jobberIPerioden": "JA",
-                    "jobberSomVanlig": true,
                     "jobberProsent": null,
                     "erLiktHverUke": true,
                     "enkeltdager": null,
-                    "fasteDager": null
+                    "fasteDager": {
+                      "mandag": "PT7H30M",
+                      "tirsdag": null,
+                      "onsdag": null,
+                      "torsdag": null,
+                      "fredag": null
+                    }
                   },
                   "planlagtArbeid": {
                     "jobberIPerioden": "JA",
-                    "jobberSomVanlig": true,
                     "jobberProsent": null,
                     "erLiktHverUke": true,
                     "enkeltdager": null,
-                    "fasteDager": null
+                    "fasteDager": {
+                      "mandag": "PT7H30M",
+                      "tirsdag": null,
+                      "onsdag": null,
+                      "torsdag": null,
+                      "fredag": null
+                    }
                   }
                 }
               },
@@ -266,19 +286,29 @@ internal class SerDesTest {
                   "jobberNormaltTimer": 40.0,
                   "historiskArbeid": {
                     "jobberIPerioden": "JA",
-                    "jobberSomVanlig": true,
                     "jobberProsent": null,
                     "erLiktHverUke": true,
                     "enkeltdager": null,
-                    "fasteDager": null
+                    "fasteDager": {
+                      "mandag": "PT7H30M",
+                      "tirsdag": null,
+                      "onsdag": null,
+                      "torsdag": null,
+                      "fredag": null
+                    }
                   },
                   "planlagtArbeid": {
                     "jobberIPerioden": "JA",
-                    "jobberSomVanlig": true,
                     "jobberProsent": null,
                     "erLiktHverUke": true,
                     "enkeltdager": null,
-                    "fasteDager": null
+                    "fasteDager": {
+                      "mandag": "PT7H30M",
+                      "tirsdag": null,
+                      "onsdag": null,
+                      "torsdag": null,
+                      "fredag": null
+                    }
                   }
                 }
               },
@@ -492,7 +522,6 @@ internal class SerDesTest {
                   "arbeidsforhold": {
                     "jobberNormaltTimer": 40.0,
                     "historiskArbeid": {
-                      "jobberSomVanlig": false,
                       "jobberProsent": 50.0,
                       "enkeltdager": [],
                       "erLiktHverUke": true,
@@ -688,7 +717,6 @@ internal class SerDesTest {
                     jobberNormaltTimer = 40.0,
                     historiskArbeid = ArbeidIPeriode(
                         jobberIPerioden = JobberIPeriodeSvar.JA,
-                        jobberSomVanlig = false,
                         jobberProsent = 50.0,
                         erLiktHverUke = true,
                         enkeltdager = listOf(),

--- a/src/test/kotlin/no/nav/helse/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/helse/SøknadUtils.kt
@@ -71,17 +71,19 @@ class SøknadUtils {
                         jobberNormaltTimer = 40.0,
                         historiskArbeid = ArbeidIPeriode(
                             jobberIPerioden = JobberIPeriodeSvar.JA,
-                            jobberSomVanlig = true,
                             erLiktHverUke = true,
                             enkeltdager = null,
-                            fasteDager = null
+                            fasteDager = PlanUkedager(
+                                mandag = Duration.ofHours(7).plusMinutes(30)
+                            )
                         ),
                         planlagtArbeid = ArbeidIPeriode(
                             jobberIPerioden = JobberIPeriodeSvar.JA,
-                            jobberSomVanlig = true,
                             erLiktHverUke = true,
                             enkeltdager = null,
-                            fasteDager = null
+                            fasteDager = PlanUkedager(
+                                mandag = Duration.ofHours(7).plusMinutes(30)
+                            )
                         )
                     )
                 ),
@@ -127,17 +129,19 @@ class SøknadUtils {
                     jobberNormaltTimer = 40.0,
                     historiskArbeid = ArbeidIPeriode(
                         jobberIPerioden = JobberIPeriodeSvar.JA,
-                        jobberSomVanlig = true,
                         erLiktHverUke = true,
                         enkeltdager = null,
-                        fasteDager = null
+                        fasteDager = PlanUkedager(
+                            mandag = Duration.ofHours(7).plusMinutes(30)
+                        )
                     ),
                     planlagtArbeid = ArbeidIPeriode(
                         jobberIPerioden = JobberIPeriodeSvar.JA,
-                        jobberSomVanlig = true,
                         erLiktHverUke = true,
                         enkeltdager = null,
-                        fasteDager = null
+                        fasteDager = PlanUkedager(
+                            mandag = Duration.ofHours(7).plusMinutes(30)
+                        )
                     )
                 )
             ),
@@ -253,16 +257,19 @@ class SøknadUtils {
                     jobberNormaltTimer = 40.0,
                     historiskArbeid = ArbeidIPeriode(
                         jobberIPerioden = JobberIPeriodeSvar.JA,
-                        jobberSomVanlig = true,
                         erLiktHverUke = true,
                         enkeltdager = null,
-                        fasteDager = null
+                        fasteDager = PlanUkedager(
+                            mandag = Duration.ofHours(7).plusMinutes(30)
+                        )
                     ),
                     planlagtArbeid = ArbeidIPeriode(
                         jobberIPerioden = JobberIPeriodeSvar.JA,
-                        jobberSomVanlig = true,
                         erLiktHverUke = true,
-                        enkeltdager = null
+                        enkeltdager = null,
+                        fasteDager = PlanUkedager(
+                            mandag = Duration.ofHours(7).plusMinutes(30)
+                        )
                     )
                 )
             ),

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatArbeidstidTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatArbeidstidTest.kt
@@ -37,7 +37,6 @@ class K9FormatArbeidstidTest {
                 planlagtArbeid = null,
                 historiskArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.JA,
-                    jobberSomVanlig = false,
                     jobberProsent = 50.0,
                     erLiktHverUke = false,
                     enkeltdager = listOf(
@@ -91,7 +90,7 @@ class K9FormatArbeidstidTest {
     }
 
     @Test
-    fun `arbeidsgivere- Kun historisk med jobberIPerioden=JA jobberSomVanlig=true -- Forventer at perioden blir fylt hvor faktiskArbeidTimerPerDag=jobberNormaltTimer`() {
+    fun `arbeidsgivere- Kun historisk med jobberIPerioden=JA -- Forventer at perioden blir fylt hvor faktiskArbeidTimerPerDag=jobberNormaltTimer`() {
         val arbeidsforholdAnsatt = ArbeidsforholdAnsatt(
             navn = "Org",
             organisasjonsnummer = "917755736",
@@ -101,10 +100,15 @@ class K9FormatArbeidstidTest {
                 planlagtArbeid = null,
                 historiskArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.JA,
-                    jobberSomVanlig = true,
                     erLiktHverUke = true,
                     enkeltdager = null,
-                    fasteDager = null
+                    fasteDager = PlanUkedager(
+                        mandag = Duration.ofHours(7).plusMinutes(30),
+                        tirsdag = Duration.ofHours(7).plusMinutes(30),
+                        onsdag = Duration.ofHours(7).plusMinutes(30),
+                        torsdag = Duration.ofHours(7).plusMinutes(30),
+                        fredag = Duration.ofHours(7).plusMinutes(30)
+                    )
                 )
             )
         )
@@ -124,10 +128,19 @@ class K9FormatArbeidstidTest {
             søknad.tilK9Format(ZonedDateTime.of(2021, 1, 10, 3, 4, 5, 6, ZoneId.of("UTC")), SøknadUtils.søker)
         søknad.validate(k9Format)
 
+        //language=json
         val forventetJson = """
         {
           "perioder": {
-            "2021-01-04/2021-01-06": {
+            "2021-01-04/2021-01-04": {
+              "faktiskArbeidTimerPerDag": "PT7H30M",
+              "jobberNormaltTimerPerDag": "PT7H30M"
+            },
+            "2021-01-05/2021-01-05": {
+              "faktiskArbeidTimerPerDag": "PT7H30M",
+              "jobberNormaltTimerPerDag": "PT7H30M"
+            },
+            "2021-01-06/2021-01-06": {
               "faktiskArbeidTimerPerDag": "PT7H30M",
               "jobberNormaltTimerPerDag": "PT7H30M"
             }
@@ -151,58 +164,7 @@ class K9FormatArbeidstidTest {
                 planlagtArbeid = null,
                 historiskArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.NEI,
-                    jobberSomVanlig = true,
-                    erLiktHverUke = true,
-                    enkeltdager = null,
-                    fasteDager = null
-                )
-            )
-        )
-
-        val søknad = SøknadUtils.defaultSøknad().copy(
-            fraOgMed = LocalDate.parse("2021-01-04"),
-            tilOgMed = LocalDate.parse("2021-01-06"),
-            arbeidsgivere = listOf(arbeidsforholdAnsatt),
-            omsorgstilbud = null,
-            utenlandsoppholdIPerioden = null,
-            ferieuttakIPerioden = null,
-            frilans = null,
-            selvstendigNæringsdrivende = null
-        )
-
-        val k9Format =
-            søknad.tilK9Format(ZonedDateTime.of(2021, 1, 10, 3, 4, 5, 6, ZoneId.of("UTC")), SøknadUtils.søker)
-        søknad.validate(k9Format)
-
-        val forventetJson = """
-        {
-          "perioder": {
-            "2021-01-04/2021-01-06": {
-              "faktiskArbeidTimerPerDag": "PT0S",
-              "jobberNormaltTimerPerDag": "PT7H30M"
-            }
-          }
-        }
-        """.trimIndent()
-
-        val json = JSONObject(k9Format.somJson()).getJSONObject("ytelse").getJSONObject("arbeidstid")
-            .getJSONArray("arbeidstakerList").getJSONObject(0).getJSONObject("arbeidstidInfo")
-        JSONAssert.assertEquals(JSONObject(forventetJson), json, true)
-    }
-
-    @Test
-    fun `arbeidsgivere- Kun historisk med jobberIPerioden=VET_IKKE -- Forventer at perioden blir fylt med 0 faktiskArbeidTimerPerDag`() {
-        val arbeidsforholdAnsatt = ArbeidsforholdAnsatt(
-            navn = "Org",
-            organisasjonsnummer = "917755736",
-            erAnsatt = true,
-            arbeidsforhold = Arbeidsforhold(
-                jobberNormaltTimer = 37.5,
-                planlagtArbeid = null,
-                historiskArbeid = ArbeidIPeriode(
-                    jobberIPerioden = JobberIPeriodeSvar.VET_IKKE,
-                    jobberSomVanlig = true,
-                    erLiktHverUke = false,
+                    erLiktHverUke = null,
                     enkeltdager = null,
                     fasteDager = null
                 )
@@ -251,7 +213,6 @@ class K9FormatArbeidstidTest {
                 historiskArbeid = null,
                 planlagtArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.JA,
-                    jobberSomVanlig = false,
                     jobberProsent = 50.0,
                     erLiktHverUke = false,
                     enkeltdager = listOf(
@@ -318,9 +279,8 @@ class K9FormatArbeidstidTest {
                 historiskArbeid = null,
                 planlagtArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.NEI,
-                    jobberSomVanlig = false,
                     jobberProsent = 50.0,
-                    erLiktHverUke = false,
+                    erLiktHverUke = null,
                     enkeltdager = null,
                     fasteDager = null
                 )
@@ -373,7 +333,6 @@ class K9FormatArbeidstidTest {
                 historiskArbeid = null,
                 planlagtArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.JA,
-                    jobberSomVanlig = false,
                     jobberProsent = 50.0,
                     enkeltdager = null,
                     erLiktHverUke = true,
@@ -431,60 +390,7 @@ class K9FormatArbeidstidTest {
     }
 
     @Test
-    fun `arbeidsgivere- Kun planlagt hvor jobberIPerioden=JA jobberSomVanlig=true  -- Forventer perioden fylt med faktiskArbeidTimerPerDag=jobberNormaltTimer`() {
-        val arbeidsforholdAnsatt = ArbeidsforholdAnsatt(
-            navn = "Org",
-            organisasjonsnummer = "917755736",
-            erAnsatt = true,
-            arbeidsforhold = Arbeidsforhold(
-                jobberNormaltTimer = 37.5,
-                historiskArbeid = null,
-                planlagtArbeid = ArbeidIPeriode(
-                    jobberIPerioden = JobberIPeriodeSvar.JA,
-                    jobberSomVanlig = true,
-                    erLiktHverUke = false,
-                    enkeltdager = null,
-                    fasteDager = null
-                )
-            )
-        )
-
-        val søknad = SøknadUtils.defaultSøknad().copy(
-            fraOgMed = LocalDate.parse("2021-01-04"), //Altså mandag, tirsdag, onsdag
-            tilOgMed = LocalDate.parse("2021-01-06"),
-            arbeidsgivere = listOf(arbeidsforholdAnsatt),
-            omsorgstilbud = null,
-            utenlandsoppholdIPerioden = null,
-            ferieuttakIPerioden = null,
-            frilans = null,
-            selvstendigNæringsdrivende = null
-        )
-
-        val k9Format = søknad.tilK9Format(
-            ZonedDateTime.of(2021, 1, 10, 3, 4, 5, 6, ZoneId.of("UTC")),
-            SøknadUtils.søker,
-            LocalDate.parse("2021-01-01")
-        )
-        søknad.validate(k9Format)
-
-        val forventetJson = """
-            {
-              "perioder": {
-                "2021-01-04/2021-01-06": {
-                  "faktiskArbeidTimerPerDag": "PT7H30M",
-                  "jobberNormaltTimerPerDag": "PT7H30M"
-                }
-              }
-            }
-        """.trimIndent()
-
-        val json = JSONObject(k9Format.somJson()).getJSONObject("ytelse").getJSONObject("arbeidstid")
-            .getJSONArray("arbeidstakerList").getJSONObject(0).getJSONObject("arbeidstidInfo")
-        JSONAssert.assertEquals(JSONObject(forventetJson), json, true)
-    }
-
-    @Test
-    fun `arbeidsgivere- Søknad med historisk og planlagt hvor jobberSomVanlig=true -- Forventer to perioder med full arbeid`() {
+    fun `arbeidsgivere- Søknad med historisk og planlagt hvor søker jobber 100% -- Forventer to perioder med full arbeid`() {
         val arbeidsforholdAnsatt = ArbeidsforholdAnsatt(
             navn = "Org",
             organisasjonsnummer = "917755736",
@@ -493,17 +399,27 @@ class K9FormatArbeidstidTest {
                 jobberNormaltTimer = 37.5,
                 planlagtArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.JA,
-                    jobberSomVanlig = true,
-                    erLiktHverUke = false,
+                    erLiktHverUke = true,
                     enkeltdager = null,
-                    fasteDager = null
+                    fasteDager = PlanUkedager(
+                        mandag = Duration.ofHours(7).plusMinutes(30),
+                        tirsdag = Duration.ofHours(7).plusMinutes(30),
+                        onsdag = Duration.ofHours(7).plusMinutes(30),
+                        torsdag = Duration.ofHours(7).plusMinutes(30),
+                        fredag = Duration.ofHours(7).plusMinutes(30)
+                    )
                 ),
                 historiskArbeid = ArbeidIPeriode(
                     jobberIPerioden = JobberIPeriodeSvar.JA,
-                    jobberSomVanlig = true,
                     erLiktHverUke = true,
                     enkeltdager = null,
-                    fasteDager = null
+                    fasteDager = PlanUkedager(
+                        mandag = Duration.ofHours(7).plusMinutes(30),
+                        tirsdag = Duration.ofHours(7).plusMinutes(30),
+                        onsdag = Duration.ofHours(7).plusMinutes(30),
+                        torsdag = Duration.ofHours(7).plusMinutes(30),
+                        fredag = Duration.ofHours(7).plusMinutes(30)
+                    )
                 )
             )
         )
@@ -534,7 +450,11 @@ class K9FormatArbeidstidTest {
                   "faktiskArbeidTimerPerDag": "PT7H30M",
                   "jobberNormaltTimerPerDag": "PT7H30M"
                 },
-                "2021-01-05/2021-01-06": {
+                "2021-01-05/2021-01-05": {
+                  "faktiskArbeidTimerPerDag": "PT7H30M",
+                  "jobberNormaltTimerPerDag": "PT7H30M"
+                },
+                "2021-01-06/2021-01-06": {
                   "faktiskArbeidTimerPerDag": "PT7H30M",
                   "jobberNormaltTimerPerDag": "PT7H30M"
                 }
@@ -628,7 +548,8 @@ class K9FormatArbeidstidTest {
             }
         """.trimIndent()
 
-        val json = JSONObject(k9Format.somJson()).getJSONObject("ytelse").getJSONObject("arbeidstid").getJSONObject("frilanserArbeidstidInfo")
+        val json = JSONObject(k9Format.somJson()).getJSONObject("ytelse").getJSONObject("arbeidstid")
+            .getJSONObject("frilanserArbeidstidInfo")
         JSONAssert.assertEquals(JSONObject(forventetJson), json, true)
     }
 
@@ -683,56 +604,17 @@ class K9FormatArbeidstidTest {
             }
         """.trimIndent()
 
-        val json = JSONObject(k9Format.somJson()).getJSONObject("ytelse").getJSONObject("arbeidstid").getJSONObject("selvstendigNæringsdrivendeArbeidstidInfo")
+        val json = JSONObject(k9Format.somJson()).getJSONObject("ytelse").getJSONObject("arbeidstid")
+            .getJSONObject("selvstendigNæringsdrivendeArbeidstidInfo")
         JSONAssert.assertEquals(JSONObject(forventetJson), json, true)
     }
 
     @Test
-    fun `Arbeidsforhold - Historisk og planlagt hvor jobberSomVanlig=true -- Forventer to perioder med fult arbeid`(){
-        val arbeidsforholdJson = Arbeidsforhold(
-            jobberNormaltTimer = 37.5,
-            historiskArbeid = ArbeidIPeriode(
-                jobberIPerioden = JobberIPeriodeSvar.JA,
-                jobberSomVanlig = true,
-                erLiktHverUke = true,
-                enkeltdager = null,
-                fasteDager = null
-            ),
-            planlagtArbeid = ArbeidIPeriode(
-                jobberIPerioden = JobberIPeriodeSvar.JA,
-                jobberSomVanlig = true,
-                erLiktHverUke = true,
-                enkeltdager = null,
-                fasteDager = null
-            )
-        ).beregnK9ArbeidstidInfo(Periode(LocalDate.parse("2021-01-01"), LocalDate.parse("2021-01-10")), LocalDate.parse("2021-01-05")).somJson()
-
-        //language=json
-        val forventetJson = """
-            {
-              "perioder": {
-                "2021-01-01/2021-01-04": {
-                  "jobberNormaltTimerPerDag": "PT7H30M",
-                  "faktiskArbeidTimerPerDag": "PT7H30M"
-                },
-                "2021-01-05/2021-01-10": {
-                  "jobberNormaltTimerPerDag": "PT7H30M",
-                  "faktiskArbeidTimerPerDag": "PT7H30M"
-                }
-              }
-            }
-        """.trimIndent()
-
-        JSONAssert.assertEquals(JSONObject(forventetJson), JSONObject(arbeidsforholdJson), true)
-    }
-
-    @Test
-    fun `Arbeidsforhold - Historisk og planlagt hvor jobberIPerioden=NEI -- Forventer to perioder fylt med 0 timer`(){
+    fun `Arbeidsforhold - Historisk og planlagt hvor jobberIPerioden=NEI -- Forventer to perioder fylt med 0 timer`() {
         val arbeidsforholdJson = Arbeidsforhold(
             jobberNormaltTimer = 37.5,
             historiskArbeid = ArbeidIPeriode(
                 jobberIPerioden = JobberIPeriodeSvar.NEI,
-                jobberSomVanlig = false,
                 jobberProsent = 50.0,
                 erLiktHverUke = true,
                 enkeltdager = null,
@@ -740,12 +622,14 @@ class K9FormatArbeidstidTest {
             ),
             planlagtArbeid = ArbeidIPeriode(
                 jobberIPerioden = JobberIPeriodeSvar.NEI,
-                jobberSomVanlig = false,
                 erLiktHverUke = true,
                 enkeltdager = null,
                 fasteDager = null
             )
-        ).beregnK9ArbeidstidInfo(Periode(LocalDate.parse("2021-01-01"), LocalDate.parse("2021-01-10")), LocalDate.parse("2021-01-05")).somJson()
+        ).beregnK9ArbeidstidInfo(
+            Periode(LocalDate.parse("2021-01-01"), LocalDate.parse("2021-01-10")),
+            LocalDate.parse("2021-01-05")
+        ).somJson()
 
         //language=json
         val forventetJson = """
@@ -767,124 +651,7 @@ class K9FormatArbeidstidTest {
     }
 
     @Test
-    fun `Kombinasjon av selvstending, ansatt og frilans -- Forventer to perioder per arbeid med full arbeid`(){
-        val arbeidIPeriodenUtenOppgittTid = ArbeidIPeriode(
-            jobberIPerioden = JobberIPeriodeSvar.JA,
-            jobberSomVanlig = true,
-            erLiktHverUke = true,
-            enkeltdager = null,
-            fasteDager = null
-        )
-
-        val arbeidsforhold = Arbeidsforhold(
-            jobberNormaltTimer = 37.5,
-            planlagtArbeid = arbeidIPeriodenUtenOppgittTid,
-            historiskArbeid = arbeidIPeriodenUtenOppgittTid
-        )
-
-        val arbeidsforholdAnsatt = ArbeidsforholdAnsatt(
-            navn = "Org",
-            organisasjonsnummer = "917755736",
-            erAnsatt = true,
-            arbeidsforhold = arbeidsforhold
-        )
-
-        val frilans = Frilans(
-            startdato = LocalDate.parse("2019-01-01"),
-            jobberFortsattSomFrilans = true,
-            arbeidsforhold = arbeidsforhold
-        )
-
-        val selvstendigNæringsdrivende = SelvstendigNæringsdrivende(
-            virksomhet = Virksomhet(
-                næringstyper = listOf(Næringstyper.JORDBRUK_SKOGBRUK),
-                fiskerErPåBladB = false,
-                fraOgMed = LocalDate.parse("2019-01-01"),
-                navnPåVirksomheten = "TullOgTøys",
-                registrertINorge = true,
-                organisasjonsnummer = "926032925",
-                yrkesaktivSisteTreFerdigliknedeÅrene = YrkesaktivSisteTreFerdigliknedeÅrene(LocalDate.now()),
-                regnskapsfører = Regnskapsfører(
-                    navn = "Kjell",
-                    telefon = "84554"
-                ),
-                harFlereAktiveVirksomheter = true
-            ),
-            arbeidsforhold = arbeidsforhold
-        )
-
-        val søknad = SøknadUtils.defaultSøknad().copy(
-            fraOgMed = LocalDate.parse("2021-01-04"), //5 dager
-            tilOgMed = LocalDate.parse("2021-01-08"),
-            arbeidsgivere = listOf(arbeidsforholdAnsatt),
-            omsorgstilbud = null,
-            utenlandsoppholdIPerioden = null,
-            ferieuttakIPerioden = null,
-            frilans = frilans,
-            selvstendigNæringsdrivende = selvstendigNæringsdrivende,
-        )
-
-        val k9Format = søknad.tilK9Format(
-            ZonedDateTime.of(2021, 1, 10, 3, 4, 5, 6, ZoneId.of("UTC")),
-            SøknadUtils.søker,
-            LocalDate.parse("2021-01-06")
-        )
-        søknad.validate(k9Format)
-
-        val json = JSONObject(k9Format.somJson()).getJSONObject("ytelse").getJSONObject("arbeidstid")
-
-        val forventetJson = """
-            {
-              "frilanserArbeidstidInfo": {
-                "perioder": {
-                  "2021-01-06/2021-01-08": {
-                    "faktiskArbeidTimerPerDag": "PT7H30M",
-                    "jobberNormaltTimerPerDag": "PT7H30M"
-                  },
-                  "2021-01-04/2021-01-05": {
-                    "faktiskArbeidTimerPerDag": "PT7H30M",
-                    "jobberNormaltTimerPerDag": "PT7H30M"
-                  }
-                }
-              },
-              "arbeidstakerList": [
-                {
-                  "arbeidstidInfo": {
-                    "perioder": {
-                      "2021-01-06/2021-01-08": {
-                        "faktiskArbeidTimerPerDag": "PT7H30M",
-                        "jobberNormaltTimerPerDag": "PT7H30M"
-                      },
-                      "2021-01-04/2021-01-05": {
-                        "faktiskArbeidTimerPerDag": "PT7H30M",
-                        "jobberNormaltTimerPerDag": "PT7H30M"
-                      }
-                    }
-                  },
-                  "organisasjonsnummer": "917755736",
-                  "norskIdentitetsnummer": null
-                }
-              ],
-              "selvstendigNæringsdrivendeArbeidstidInfo": {
-                "perioder": {
-                  "2021-01-06/2021-01-08": {
-                    "faktiskArbeidTimerPerDag": "PT7H30M",
-                    "jobberNormaltTimerPerDag": "PT7H30M"
-                  },
-                  "2021-01-04/2021-01-05": {
-                    "faktiskArbeidTimerPerDag": "PT7H30M",
-                    "jobberNormaltTimerPerDag": "PT7H30M"
-                  }
-                }
-              }
-            }
-        """.trimIndent()
-
-        JSONAssert.assertEquals(JSONObject(forventetJson), json, true)
-    }
-
-    @Test
-    fun `Kombinasjon av selvstending, ansatt og frilans med arbeidsforhold=null-- Forventer en periode per arbeid med 0-0 timer`(){
+    fun `Kombinasjon av selvstending, ansatt og frilans med arbeidsforhold=null-- Forventer en periode per arbeid med 0-0 timer`() {
         val arbeidsforholdAnsatt = ArbeidsforholdAnsatt(
             navn = "Org",
             organisasjonsnummer = "917755736",
@@ -975,10 +742,9 @@ class K9FormatArbeidstidTest {
     }
 
     @Test
-    fun `Frilans hvor start og sluttdato er innenfor søknadsperioden -- Forventer at alt utenfor blir fylt med 0 timer`(){
+    fun `Frilans hvor start og sluttdato er innenfor søknadsperioden -- Forventer at alt utenfor blir fylt med 0 timer`() {
         val arbeidIPeriode = ArbeidIPeriode(
             jobberIPerioden = JobberIPeriodeSvar.JA,
-            jobberSomVanlig = false,
             jobberProsent = 50.0,
             erLiktHverUke = true,
             enkeltdager = null,
@@ -989,7 +755,7 @@ class K9FormatArbeidstidTest {
                 torsdag = Duration.ofHours(3),
                 fredag = Duration.ofHours(3),
 
-            )
+                )
         )
 
         val arbeidsforhold = Arbeidsforhold(

--- a/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/k9format/K9FormatTest.kt
@@ -2,7 +2,13 @@ package no.nav.helse.k9format
 
 import no.nav.helse.SøknadUtils
 import no.nav.helse.soker.Søker
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.Enkeltdag
+import no.nav.helse.soknad.Ferieuttak
+import no.nav.helse.soknad.FerieuttakIPerioden
+import no.nav.helse.soknad.HistoriskOmsorgstilbud
+import no.nav.helse.soknad.Omsorgstilbud
+import no.nav.helse.soknad.PlanUkedager
+import no.nav.helse.soknad.PlanlagtOmsorgstilbud
 import no.nav.k9.søknad.JsonUtils
 import no.nav.k9.søknad.felles.type.Periode
 import org.skyscreamer.jsonassert.JSONAssert
@@ -166,17 +172,33 @@ class K9FormatTest {
                       "norskIdentitetsnummer": null,
                       "organisasjonsnummer": "917755736",
                       "arbeidstidInfo": {
-                        "perioder": {
-                          "2021-01-01/2021-01-04": {
-                            "jobberNormaltTimerPerDag": "PT8H",
-                            "faktiskArbeidTimerPerDag": "PT8H"
-                          },
-                          "2021-01-05/2021-01-10": {
-                            "jobberNormaltTimerPerDag": "PT8H",
-                            "faktiskArbeidTimerPerDag": "PT8H"
-                          }
-                        }
-                      }
+                         "perioder": {
+                           "2021-01-01/2021-01-01": {
+                             "jobberNormaltTimerPerDag": "PT8H",
+                             "faktiskArbeidTimerPerDag": "PT0S"
+                           },
+                           "2021-01-04/2021-01-04": {
+                             "jobberNormaltTimerPerDag": "PT8H",
+                             "faktiskArbeidTimerPerDag": "PT7H30M"
+                           },
+                           "2021-01-05/2021-01-05": {
+                               "jobberNormaltTimerPerDag": "PT8H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                           },
+                           "2021-01-06/2021-01-06": {
+                                "jobberNormaltTimerPerDag": "PT8H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                           },
+                           "2021-01-07/2021-01-07": {
+                                "jobberNormaltTimerPerDag": "PT8H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                           },
+                           "2021-01-08/2021-01-08": {
+                                "jobberNormaltTimerPerDag": "PT8H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                           }
+                         }
+                       }
                     },
                     {
                       "norskIdentitetsnummer": null,
@@ -193,27 +215,59 @@ class K9FormatTest {
                   ],
                   "frilanserArbeidstidInfo": {
                     "perioder": {
-                      "2021-01-01/2021-01-04": {
-                        "jobberNormaltTimerPerDag": "PT8H",
-                        "faktiskArbeidTimerPerDag": "PT8H"
-                      },
-                      "2021-01-05/2021-01-10": {
-                        "jobberNormaltTimerPerDag": "PT8H",
-                        "faktiskArbeidTimerPerDag": "PT8H"
-                      }
-                    }
+                       "2021-01-01/2021-01-01": {
+                         "jobberNormaltTimerPerDag": "PT8H",
+                         "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-04/2021-01-04": {
+                         "jobberNormaltTimerPerDag": "PT8H",
+                         "faktiskArbeidTimerPerDag": "PT7H30M"
+                       },
+                       "2021-01-05/2021-01-05": {
+                           "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-06/2021-01-06": {
+                            "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-07/2021-01-07": {
+                            "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-08/2021-01-08": {
+                            "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       }
+                     }
                   },
                   "selvstendigNæringsdrivendeArbeidstidInfo": {
                     "perioder": {
-                      "2021-01-01/2021-01-04": {
-                        "jobberNormaltTimerPerDag": "PT8H",
-                        "faktiskArbeidTimerPerDag": "PT8H"
-                      },
-                      "2021-01-05/2021-01-10": {
-                        "jobberNormaltTimerPerDag": "PT8H",
-                        "faktiskArbeidTimerPerDag": "PT8H"
-                      }
-                    }
+                       "2021-01-01/2021-01-01": {
+                         "jobberNormaltTimerPerDag": "PT8H",
+                         "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-04/2021-01-04": {
+                         "jobberNormaltTimerPerDag": "PT8H",
+                         "faktiskArbeidTimerPerDag": "PT7H30M"
+                       },
+                       "2021-01-05/2021-01-05": {
+                           "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-06/2021-01-06": {
+                            "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-07/2021-01-07": {
+                            "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       },
+                       "2021-01-08/2021-01-08": {
+                            "jobberNormaltTimerPerDag": "PT8H",
+                            "faktiskArbeidTimerPerDag": "PT0S"
+                       }
+                     }
                   }
                 },
                 "uttak": {
@@ -252,7 +306,10 @@ class K9FormatTest {
                     fredag = Duration.ofHours(5)
                 )
             )
-        ).tilK9Tilsynsordning(dagensDato = LocalDate.parse("2021-01-04"), periode = Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+        ).tilK9Tilsynsordning(
+            dagensDato = LocalDate.parse("2021-01-04"),
+            periode = Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08"))
+        )
 
         assertEquals(5, k9Tilsynsordning.perioder.size)
 
@@ -294,7 +351,10 @@ class K9FormatTest {
                     fredag = Duration.ofHours(5)
                 )
             )
-        ).tilK9Tilsynsordning(dagensDato = LocalDate.parse("2021-01-06"), periode = Periode(LocalDate.parse("2021-01-06"), LocalDate.parse("2021-01-11")))
+        ).tilK9Tilsynsordning(
+            dagensDato = LocalDate.parse("2021-01-06"),
+            periode = Periode(LocalDate.parse("2021-01-06"), LocalDate.parse("2021-01-11"))
+        )
 
         assertEquals(4, k9Tilsynsordning.perioder.size)
 
@@ -333,7 +393,10 @@ class K9FormatTest {
                     fredag = Duration.ofHours(5)
                 )
             )
-        ).tilK9Tilsynsordning(dagensDato = LocalDate.parse("2021-01-04"), periode = Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+        ).tilK9Tilsynsordning(
+            dagensDato = LocalDate.parse("2021-01-04"),
+            periode = Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08"))
+        )
 
         assertEquals(4, k9Tilsynsordning.perioder.size)
 
@@ -393,7 +456,10 @@ class K9FormatTest {
                     fredag = Duration.ofHours(10)
                 )
             )
-        ).tilK9Tilsynsordning(dagensDato = LocalDate.parse("2021-01-04"), periode = Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08")))
+        ).tilK9Tilsynsordning(
+            dagensDato = LocalDate.parse("2021-01-04"),
+            periode = Periode(LocalDate.parse("2021-01-04"), LocalDate.parse("2021-01-08"))
+        )
 
         assertEquals(5, k9Tilsynsordning.perioder.size)
 
@@ -462,7 +528,10 @@ class K9FormatTest {
                     fredag = Duration.ofHours(1)
                 )
             )
-        ).tilK9Tilsynsordning(Periode(LocalDate.parse("2021-09-03"), LocalDate.parse("2021-09-13")), LocalDate.parse("2021-09-03"))
+        ).tilK9Tilsynsordning(
+            Periode(LocalDate.parse("2021-09-03"), LocalDate.parse("2021-09-13")),
+            LocalDate.parse("2021-09-03")
+        )
 
         assertEquals(9, tilsynsordning.perioder.size)
     }

--- a/src/test/kotlin/no/nav/helse/validering/ArbeidsforholdValideringTest.kt
+++ b/src/test/kotlin/no/nav/helse/validering/ArbeidsforholdValideringTest.kt
@@ -19,10 +19,9 @@ class ArbeidsforholdValideringTest {
     )
 
     @Test
-    fun `Ved jobberIPerioden=JA og jobberSomVanlig=false skal den feile dersom enkeltdager og fasteDager er null`(){
+    fun `Ved jobberIPerioden=JA og erLiktHverUke=false skal den feile dersom enkeltdager er null`(){
         val arbeidIPerioden = ArbeidIPeriode(
             jobberIPerioden = JobberIPeriodeSvar.JA,
-            jobberSomVanlig = false,
             jobberProsent = 50.0,
             erLiktHverUke = false,
             enkeltdager = null,
@@ -31,35 +30,16 @@ class ArbeidsforholdValideringTest {
 
         val arbeidsforhold = arbeidsforhold.copy(historiskArbeid = arbeidIPerioden)
 
-        val forventetFeil = "Dersom jobberIPerioden=JA og jobberSomVanlig=false må enkeltdager eller faste dager være satt."
+        val forventetFeil = "Dersom erLiktHverUke er true, kan ikke enkeltdager være null."
         val feil = arbeidsforhold.valider("frilans").first().reason
 
         assertEquals(forventetFeil, feil)
     }
 
     @Test
-    fun `Ved jobberIPerioden=JA og jobberSomVanlig=true skal den feile dersom enkeltdager eller fasteDager er satt`(){
-        val arbeidIPerioden = ArbeidIPeriode(
-            jobberIPerioden = JobberIPeriodeSvar.JA,
-            jobberSomVanlig = true,
-            erLiktHverUke = false,
-            enkeltdager = listOf(Enkeltdag(LocalDate.now(), Duration.ofHours(2))),
-            fasteDager = null
-        )
-
-        val arbeidsforhold = arbeidsforhold.copy(historiskArbeid = arbeidIPerioden)
-
-        val forventetFeil = "Dersom jobberIPerioden=JA og jobberSomVanlig=true så kan ikke enkeltdager eller faste dager være satt."
-        val feil = arbeidsforhold.valider("frilans").first().reason
-
-        assertEquals(forventetFeil, feil)
-    }
-
-    @Test
-    fun `Ved jobberIPerioden=NEI skal den feile dersom enkeltdager eller fasteDager er satt`(){
+    fun `Ved jobberIPerioden=NEI skal den feile dersom enkeltdager er satt`(){
         val arbeidIPerioden = ArbeidIPeriode(
             jobberIPerioden = JobberIPeriodeSvar.NEI,
-            jobberSomVanlig = true,
             erLiktHverUke = false,
             enkeltdager = listOf(Enkeltdag(LocalDate.now(), Duration.ofHours(2))),
             fasteDager = null
@@ -67,25 +47,7 @@ class ArbeidsforholdValideringTest {
 
         val arbeidsforhold = arbeidsforhold.copy(historiskArbeid = arbeidIPerioden)
 
-        val forventetFeil = "Dersom jobberIPerioden=NEI/VET_IKKE så kan ikke enkeltdager eller faste dager være satt."
-        val feil = arbeidsforhold.valider("frilans").first().reason
-
-        assertEquals(forventetFeil, feil)
-    }
-
-    @Test
-    fun `Ved jobberIPerioden=VET_IKKE skal den feile dersom enkeltdager eller fasteDager er satt`(){
-        val arbeidIPerioden = ArbeidIPeriode(
-            jobberIPerioden = JobberIPeriodeSvar.VET_IKKE,
-            jobberSomVanlig = true,
-            erLiktHverUke = false,
-            enkeltdager = listOf(Enkeltdag(LocalDate.now(), Duration.ofHours(2))),
-            fasteDager = null
-        )
-
-        val arbeidsforhold = arbeidsforhold.copy(historiskArbeid = arbeidIPerioden)
-
-        val forventetFeil = "Dersom jobberIPerioden=NEI/VET_IKKE så kan ikke enkeltdager eller faste dager være satt."
+        val forventetFeil = "Dersom jobberIPerioden=NEI så kan ikke enkeltdager være satt."
         val feil = arbeidsforhold.valider("frilans").first().reason
 
         assertEquals(forventetFeil, feil)


### PR DESCRIPTION
- Fjerner jobberSomNormalt. Dersom søker jobber 100% i søknadsperioden, skal det oppgis av søker selv i dialogen.
- Fjerner VET_IKKE som JobberIPeriodeSvar.
- Endrer på validering.
- Justerer tester etter endringer.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>