### PR TITLE
Utvider med støtte for UtenlandskNæring.

### DIFF
--- a/src/main/kotlin/no/nav/helse/general/ValideringUtils.kt
+++ b/src/main/kotlin/no/nav/helse/general/ValideringUtils.kt
@@ -11,7 +11,7 @@ internal fun MutableList<String>.kreverIkkeNull(verdi: Any?, feilmelding: String
     if (verdi == null) this.add(feilmelding)
 }
 
-internal fun MutableList<String>.somViolation(): Set<Violation> = this.map {
+internal fun List<String>.somViolation(): Set<Violation> = this.map {
     Violation(
         parameterName = "valideringsfeil",
         parameterType = ParameterType.ENTITY,

--- a/src/main/kotlin/no/nav/helse/k9format/K9OpptjeningAktivitet.kt
+++ b/src/main/kotlin/no/nav/helse/k9format/K9OpptjeningAktivitet.kt
@@ -1,9 +1,9 @@
 package no.nav.helse.k9format
 
-import no.nav.helse.soknad.Næringstyper
 import no.nav.helse.soknad.Søknad
 import no.nav.helse.soknad.Virksomhet
 import no.nav.helse.soknad.domene.Frilans
+import no.nav.helse.soknad.domene.Næringstyper
 import no.nav.k9.søknad.felles.opptjening.Frilanser
 import no.nav.k9.søknad.felles.opptjening.OpptjeningAktivitet
 import no.nav.k9.søknad.felles.opptjening.SelvstendigNæringsdrivende

--- a/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
@@ -21,7 +21,7 @@ data class KomplettSøknad(
     val medlemskap: Medlemskap,
     val utenlandsoppholdIPerioden: UtenlandsoppholdIPerioden,
     val opptjeningIUtlandet: List<OpptjeningIUtlandet>,
-    val utenlandskNæring: List<UtenlandskNæring>,
+    val utenlandskNæring: List<UtenlandskNæring>? = null,
     val ferieuttakIPerioden: FerieuttakIPerioden?,
     val harMedsøker: Boolean? = null,
     val samtidigHjemme: Boolean?,

--- a/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/KomplettSøknad.kt
@@ -3,6 +3,7 @@ package no.nav.helse.soknad
 import no.nav.helse.soker.Søker
 import no.nav.helse.soknad.domene.Frilans
 import no.nav.helse.soknad.domene.OpptjeningIUtlandet
+import no.nav.helse.soknad.domene.UtenlandskNæring
 import no.nav.k9.søknad.Søknad
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -20,6 +21,7 @@ data class KomplettSøknad(
     val medlemskap: Medlemskap,
     val utenlandsoppholdIPerioden: UtenlandsoppholdIPerioden,
     val opptjeningIUtlandet: List<OpptjeningIUtlandet>,
+    val utenlandskNæring: List<UtenlandskNæring>,
     val ferieuttakIPerioden: FerieuttakIPerioden?,
     val harMedsøker: Boolean? = null,
     val samtidigHjemme: Boolean?,

--- a/src/main/kotlin/no/nav/helse/soknad/Land.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Land.kt
@@ -2,49 +2,57 @@ package no.nav.helse.soknad
 
 import no.nav.helse.dusseldorf.ktor.core.ParameterType
 import no.nav.helse.dusseldorf.ktor.core.Violation
+import no.nav.helse.general.krever
 import java.util.*
 
-/**
- * ISO 3166 alpha-3 landkode.
- *
- * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
- */
-
-private val LANSKODER: MutableSet<String> = Locale.getISOCountries(Locale.IsoCountryCode.PART1_ALPHA3)
-
-data class Land(val landkode: String, val landnavn: String)
-
-internal fun Land.valider(feltnavn: String) = mutableSetOf<Violation>().apply {
-    if (landkode.isBlank()) {
-        add(
-            Violation(
-                parameterName = "${feltnavn}.landkode",
-                parameterType = ParameterType.ENTITY,
-                reason = "Landkode kan ikke være blank.",
-                invalidValue = landkode
-            )
-        )
+class Land(
+    val landkode: String,
+    val landnavn: String
+) {
+    companion object{
+        // ISO 3166 alpha-3 landkode - https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+        internal val LANDKODER: MutableSet<String> = Locale.getISOCountries(Locale.IsoCountryCode.PART1_ALPHA3)
     }
 
-    if (!LANSKODER.contains(landkode)) {
-        add(
-            Violation(
-                parameterName = "${feltnavn}.landkode",
-                parameterType = ParameterType.ENTITY,
-                reason = "Landkode er ikke en gyldig ISO 3166-1 alpha-3 kode.",
-                invalidValue = landkode
-            )
-        )
+    override fun equals(other: Any?) = this === other || other is Land && this.equals(other)
+    private fun equals(other: Land) = this.landkode == other.landkode && this.landnavn == other.landnavn
+    internal fun validerV2(felt: String) = mutableListOf<String>().apply {
+        krever(LANDKODER.contains(landkode), "$felt.Landkode '$landkode' er ikke en gyldig ISO 3166-1 alpha-3 kode.")
+        krever(landnavn.isNotBlank(), "$felt.landnavn kan ikke være tomt eller blankt.")
     }
 
-    if (landnavn.isBlank()) {
-        add(
-            Violation(
-                parameterName = "${feltnavn}.landnavn",
-                parameterType = ParameterType.ENTITY,
-                reason = "Landnavn kan ikke være blank.",
-                invalidValue = landnavn
+    internal fun valider(feltnavn: String) = mutableSetOf<Violation>().apply {
+        if (landkode.isBlank()) {
+            add(
+                Violation(
+                    parameterName = "${feltnavn}.landkode",
+                    parameterType = ParameterType.ENTITY,
+                    reason = "Landkode kan ikke være blank.",
+                    invalidValue = landkode
+                )
             )
-        )
+        }
+
+        if (!LANDKODER.contains(landkode)) {
+            add(
+                Violation(
+                    parameterName = "${feltnavn}.landkode",
+                    parameterType = ParameterType.ENTITY,
+                    reason = "Landkode er ikke en gyldig ISO 3166-1 alpha-3 kode.",
+                    invalidValue = landkode
+                )
+            )
+        }
+
+        if (landnavn.isBlank()) {
+            add(
+                Violation(
+                    parameterName = "${feltnavn}.landnavn",
+                    parameterType = ParameterType.ENTITY,
+                    reason = "Landnavn kan ikke være blank.",
+                    invalidValue = landnavn
+                )
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/helse/soknad/SelvstendigNæringsdrivende.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SelvstendigNæringsdrivende.kt
@@ -3,6 +3,7 @@ package no.nav.helse.soknad
 import com.fasterxml.jackson.annotation.JsonFormat
 import no.nav.helse.dusseldorf.ktor.core.ParameterType
 import no.nav.helse.dusseldorf.ktor.core.Violation
+import no.nav.helse.soknad.domene.Næringstyper
 import no.nav.helse.soknad.domene.arbeid.Arbeidsforhold
 import no.nav.k9.søknad.ytelse.psb.v1.arbeidstid.ArbeidstidInfo
 import java.time.LocalDate
@@ -38,13 +39,6 @@ data class Virksomhet(
 data class YrkesaktivSisteTreFerdigliknedeÅrene(
     val oppstartsdato: LocalDate
 )
-
-enum class Næringstyper {
-    FISKE,
-    JORDBRUK_SKOGBRUK,
-    DAGMAMMA,
-    ANNEN
-}
 
 data class VarigEndring(
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
@@ -32,7 +32,7 @@ data class Søknad(
     val utenlandsoppholdIPerioden: UtenlandsoppholdIPerioden,
     val ferieuttakIPerioden: FerieuttakIPerioden?,
     val opptjeningIUtlandet: List<OpptjeningIUtlandet> = listOf(),
-    val utenlandskNæring: List<UtenlandskNæring> = listOf(),
+    val utenlandskNæring: List<UtenlandskNæring>? = null, // TODO: 17/06/2022 Fjerne nullable når frontend er prodsatt
     val harMedsøker: Boolean? = null,
     val samtidigHjemme: Boolean? = null,
     val harForståttRettigheterOgPlikter: Boolean,

--- a/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/Søknad.kt
@@ -6,6 +6,7 @@ import no.nav.helse.barn.Barn
 import no.nav.helse.soker.Søker
 import no.nav.helse.soknad.domene.Frilans
 import no.nav.helse.soknad.domene.OpptjeningIUtlandet
+import no.nav.helse.soknad.domene.UtenlandskNæring
 import no.nav.k9.søknad.Søknad
 import java.net.URL
 import java.time.LocalDate
@@ -31,6 +32,7 @@ data class Søknad(
     val utenlandsoppholdIPerioden: UtenlandsoppholdIPerioden,
     val ferieuttakIPerioden: FerieuttakIPerioden?,
     val opptjeningIUtlandet: List<OpptjeningIUtlandet> = listOf(),
+    val utenlandskNæring: List<UtenlandskNæring> = listOf(),
     val harMedsøker: Boolean? = null,
     val samtidigHjemme: Boolean? = null,
     val harForståttRettigheterOgPlikter: Boolean,
@@ -66,6 +68,7 @@ data class Søknad(
         medlemskap = medlemskap,
         ferieuttakIPerioden = ferieuttakIPerioden,
         opptjeningIUtlandet = opptjeningIUtlandet,
+        utenlandskNæring = utenlandskNæring,
         utenlandsoppholdIPerioden = utenlandsoppholdIPerioden,
         harMedsøker = harMedsøker!!,
         samtidigHjemme = samtidigHjemme,
@@ -89,12 +92,12 @@ private fun List<Barn>.hentIdentitetsnummerForBarn(aktørId: String?): String? {
     return this.firstOrNull(){ it.aktørId == aktørId}?.identitetsnummer
 }
 
-enum class BarnRelasjon(val utskriftsvennlig: String) {
-    MOR("MOR"),
-    MEDMOR("MEDMOR"),
-    FAR("FAR"),
-    FOSTERFORELDER("FOSTERFORELDER"),
-    ANNET("ANNET")
+enum class BarnRelasjon {
+    MOR,
+    MEDMOR,
+    FAR,
+    FOSTERFORELDER,
+    ANNET
 }
 
 data class Medlemskap(

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -5,6 +5,7 @@ import no.nav.helse.dusseldorf.ktor.core.Throwblem
 import no.nav.helse.dusseldorf.ktor.core.ValidationProblemDetails
 import no.nav.helse.dusseldorf.ktor.core.Violation
 import no.nav.helse.general.somViolation
+import no.nav.helse.soknad.domene.UtenlandskNæring.Companion.valider
 import no.nav.helse.soknad.domene.valider
 import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarnSøknadValidator
 import java.time.LocalDate
@@ -134,6 +135,8 @@ internal fun Søknad.validate() {
     violations.addAll(arbeidsgivere.validate())
 
     violations.addAll(selvstendigNæringsdrivende.valider())
+
+    violations.addAll(utenlandskNæring.valider("utenlandskNæring").somViolation())
 
     violations.addAll(frilans.valider("frilans").somViolation())
 

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadValidator.kt
@@ -136,7 +136,7 @@ internal fun Søknad.validate() {
 
     violations.addAll(selvstendigNæringsdrivende.valider())
 
-    violations.addAll(utenlandskNæring.valider("utenlandskNæring").somViolation())
+    utenlandskNæring?.let { violations.addAll(utenlandskNæring.valider("utenlandskNæring").somViolation()) }
 
     violations.addAll(frilans.valider("frilans").somViolation())
 

--- a/src/main/kotlin/no/nav/helse/soknad/domene/Næringstyper.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/domene/Næringstyper.kt
@@ -1,0 +1,8 @@
+package no.nav.helse.soknad.domene
+
+enum class Næringstyper {
+    FISKE,
+    JORDBRUK_SKOGBRUK,
+    DAGMAMMA,
+    ANNEN
+}

--- a/src/main/kotlin/no/nav/helse/soknad/domene/OpptjeningIUtlandet.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/domene/OpptjeningIUtlandet.kt
@@ -2,7 +2,6 @@ package no.nav.helse.soknad.domene
 
 import no.nav.helse.dusseldorf.ktor.core.Violation
 import no.nav.helse.soknad.Land
-import no.nav.helse.soknad.valider
 import java.time.LocalDate
 
 data class OpptjeningIUtlandet(

--- a/src/main/kotlin/no/nav/helse/soknad/domene/UtenlandskNæring.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/domene/UtenlandskNæring.kt
@@ -1,0 +1,30 @@
+package no.nav.helse.soknad.domene
+
+import no.nav.helse.general.krever
+import no.nav.helse.soknad.Land
+import java.time.LocalDate
+
+class UtenlandskNæring(
+    val næringstype: Næringstyper,
+    val navnPåVirksomheten: String,
+    val land: Land,
+    val identifikasjonsnummer: String,
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate? = null
+) {
+    companion object {
+        internal fun List<UtenlandskNæring>.valider(felt: String) = this.flatMapIndexed { index, bosted ->
+            bosted.valider("$felt[$index]")
+        }
+    }
+
+    internal fun valider(felt: String) = mutableListOf<String>().apply {
+        addAll(land.validerV2("$felt.land"))
+        tilOgMed?.let { krever(tilOgMed.erLikEllerEtter(fraOgMed), "$felt.tilOgMed må være lik eller etter fraOgMed") }
+    }
+
+    override fun equals(other: Any?) = other === this || other is UtenlandskNæring && this.equals(other)
+    private fun equals(other: UtenlandskNæring) = this.identifikasjonsnummer == other.identifikasjonsnummer && this.navnPåVirksomheten == other.navnPåVirksomheten
+}
+
+internal fun LocalDate.erLikEllerEtter(tilOgMedDato: LocalDate) = this.isEqual(tilOgMedDato) || this.isAfter(tilOgMedDato)

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -13,6 +13,7 @@ import no.nav.helse.innsyn.InnsynBarn
 import no.nav.helse.k9format.defaultK9FormatPSB
 import no.nav.helse.k9format.defaultK9SakInnsynSøknad
 import no.nav.helse.soknad.*
+import no.nav.helse.soknad.domene.Næringstyper
 import no.nav.helse.soknad.domene.arbeid.*
 import no.nav.helse.wiremock.*
 import no.nav.security.mock.oauth2.MockOAuth2Server

--- a/src/test/kotlin/no/nav/helse/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/helse/SerDesTest.kt
@@ -3,9 +3,7 @@ package no.nav.helse
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.helse.soker.Søker
 import no.nav.helse.soknad.*
-import no.nav.helse.soknad.domene.Frilans
-import no.nav.helse.soknad.domene.OpptjeningIUtlandet
-import no.nav.helse.soknad.domene.OpptjeningType
+import no.nav.helse.soknad.domene.*
 import no.nav.helse.soknad.domene.arbeid.*
 import org.skyscreamer.jsonassert.JSONAssert
 import java.time.Duration
@@ -213,6 +211,7 @@ internal class SerDesTest {
                   "tilOgMed": "2022-01-10"
                 }
               ],
+              "utenlandskNæring" : [],
               "harMedsøker": true,
               "harBekreftetOpplysninger": true,
               "harForståttRettigheterOgPlikter": true,
@@ -485,6 +484,19 @@ internal class SerDesTest {
                   }
                 ]
               },
+              "utenlandskNæring" : [
+                {
+                  "næringstype" : "JORDBRUK_SKOGBRUK",
+                  "navnPåVirksomheten" : "Flush AS",
+                  "land" : {
+                    "landkode" : "NLD",
+                    "landnavn" : "Nederland"
+                  },
+                  "identifikasjonsnummer" : "123ABC",
+                  "fraOgMed" : "2022-01-05",
+                  "tilOgMed" : null
+                }
+              ],
               "beredskap": {
                 "beredskap": true,
                 "tilleggsinformasjon": "Ikke beredskap"
@@ -638,6 +650,15 @@ internal class SerDesTest {
                     ),
                     fraOgMed = LocalDate.parse("2022-01-01"),
                     tilOgMed = LocalDate.parse("2022-01-10")
+                )
+            ),
+            utenlandskNæring = listOf(
+                UtenlandskNæring(
+                    næringstype = Næringstyper.JORDBRUK_SKOGBRUK,
+                    navnPåVirksomheten = "Flush AS",
+                    land = Land("NLD", "Nederland"),
+                    identifikasjonsnummer = "123ABC",
+                    fraOgMed = LocalDate.parse("2022-01-05")
                 )
             ),
             utenlandsoppholdIPerioden = UtenlandsoppholdIPerioden(

--- a/src/test/kotlin/no/nav/helse/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/helse/SerDesTest.kt
@@ -211,7 +211,7 @@ internal class SerDesTest {
                   "tilOgMed": "2022-01-10"
                 }
               ],
-              "utenlandskNæring" : [],
+              "utenlandskNæring" : null,
               "harMedsøker": true,
               "harBekreftetOpplysninger": true,
               "harForståttRettigheterOgPlikter": true,

--- a/src/test/kotlin/no/nav/helse/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/helse/SøknadUtils.kt
@@ -3,6 +3,7 @@ package no.nav.helse
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.helse.soknad.*
 import no.nav.helse.soknad.domene.Frilans
+import no.nav.helse.soknad.domene.Næringstyper
 import no.nav.helse.soknad.domene.OpptjeningIUtlandet
 import no.nav.helse.soknad.domene.OpptjeningType
 import no.nav.helse.soknad.domene.arbeid.*

--- a/src/test/kotlin/no/nav/helse/TestUtils.kt
+++ b/src/test/kotlin/no/nav/helse/TestUtils.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.http.Request
 import io.ktor.http.*
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.Assert
+import kotlin.test.assertContains
 
 class TestUtils {
     companion object {
@@ -29,11 +30,15 @@ class TestUtils {
             }
         }
 
-        internal fun MutableList<String>.validerFeil(antallFeil: Int) {
+        internal fun List<String>.verifiserFeil(antallFeil: Int, valideringsfeil: List<String> = listOf()) {
             Assert.assertEquals(antallFeil, this.size)
+
+            valideringsfeil.forEach {
+                assertContains(this, it)
+            }
         }
 
-        internal fun MutableList<String>.validerIngenFeil() {
+        internal fun List<String>.verifiserIngenFeil() {
             Assert.assertTrue(this.isEmpty())
         }
     }

--- a/src/test/kotlin/no/nav/helse/VirksomhetValidationTest.kt
+++ b/src/test/kotlin/no/nav/helse/VirksomhetValidationTest.kt
@@ -1,7 +1,11 @@
 package no.nav.helse
 
 import no.nav.helse.dusseldorf.ktor.core.Violation
-import no.nav.helse.soknad.*
+import no.nav.helse.soknad.Land
+import no.nav.helse.soknad.Virksomhet
+import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
+import no.nav.helse.soknad.domene.Næringstyper
+import no.nav.helse.soknad.validate
 import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/test/kotlin/no/nav/helse/domene/FrilansTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/FrilansTest.kt
@@ -1,7 +1,7 @@
 package no.nav.helse.domene
 
-import no.nav.helse.TestUtils.Companion.validerFeil
-import no.nav.helse.TestUtils.Companion.validerIngenFeil
+import no.nav.helse.TestUtils.Companion.verifiserFeil
+import no.nav.helse.TestUtils.Companion.verifiserIngenFeil
 import no.nav.helse.soknad.PlanUkedager
 import no.nav.helse.soknad.domene.Frilans
 import no.nav.helse.soknad.domene.arbeid.*
@@ -66,7 +66,7 @@ class FrilansTest {
                     fasteDager = null
                 )
             )
-        ).valider("test").validerFeil(3)
+        ).valider("test").verifiserFeil(3)
     }
 
     @Test
@@ -77,7 +77,7 @@ class FrilansTest {
             jobberFortsattSomFrilans = true,
             harInntektSomFrilanser = true,
             arbeidsforhold = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test
@@ -88,7 +88,7 @@ class FrilansTest {
             jobberFortsattSomFrilans = true,
             harInntektSomFrilanser = true,
             arbeidsforhold = null
-        ).valider("test").validerIngenFeil()
+        ).valider("test").verifiserIngenFeil()
     }
 
     @Test
@@ -99,7 +99,7 @@ class FrilansTest {
             jobberFortsattSomFrilans = true,
             harInntektSomFrilanser = true,
             arbeidsforhold = null
-        ).valider("test").validerIngenFeil()
+        ).valider("test").verifiserIngenFeil()
     }
 
     @Test
@@ -110,7 +110,7 @@ class FrilansTest {
             jobberFortsattSomFrilans = null,
             harInntektSomFrilanser = true,
             arbeidsforhold = null
-        ).valider("test").validerFeil(2)
+        ).valider("test").verifiserFeil(2)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/domene/UtenlandskNæringTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/UtenlandskNæringTest.kt
@@ -1,0 +1,82 @@
+package no.nav.helse.domene
+
+import no.nav.helse.TestUtils.Companion.verifiserFeil
+import no.nav.helse.TestUtils.Companion.verifiserIngenFeil
+import no.nav.helse.soknad.Land
+import no.nav.helse.soknad.domene.Næringstyper
+import no.nav.helse.soknad.domene.UtenlandskNæring
+import no.nav.helse.soknad.domene.UtenlandskNæring.Companion.valider
+import java.time.LocalDate
+import kotlin.test.Test
+
+class UtenlandskNæringTest {
+
+    @Test
+    fun `Gyldig utenlandskNæring gir ingen valideringsfeil`() {
+        UtenlandskNæring(
+            næringstype = Næringstyper.JORDBRUK_SKOGBRUK,
+            navnPåVirksomheten = "Flush AS",
+            land = Land("NLD", "Nederland"),
+            identifikasjonsnummer = "123ABC",
+            fraOgMed = LocalDate.parse("2022-01-01"),
+            tilOgMed = LocalDate.parse("2022-03-01")
+        ).valider("utenlandskNæring[0]").verifiserIngenFeil()
+    }
+
+    @Test
+    fun `UtenlandskNæring med ugyldig land gir valideringsfeil`() {
+        UtenlandskNæring(
+            næringstype = Næringstyper.JORDBRUK_SKOGBRUK,
+            navnPåVirksomheten = "Flush AS",
+            land = Land("ABC", " "),
+            identifikasjonsnummer = "123ABC",
+            fraOgMed = LocalDate.parse("2022-01-01"),
+            tilOgMed = LocalDate.parse("2022-03-01")
+        ).valider("utenlandskNæring[0]").verifiserFeil(2,
+            listOf(
+                "utenlandskNæring[0].land.Landkode 'ABC' er ikke en gyldig ISO 3166-1 alpha-3 kode.",
+                "utenlandskNæring[0].land.landnavn kan ikke være tomt eller blankt."
+            )
+        )
+    }
+
+    @Test
+    fun `UtenlandskNæring med tilOgMed før fraOgMed gir valideringsfeil`() {
+        UtenlandskNæring(
+            næringstype = Næringstyper.JORDBRUK_SKOGBRUK,
+            navnPåVirksomheten = "Flush AS",
+            land = Land("NLD", "Nederland"),
+            identifikasjonsnummer = "123ABC",
+            fraOgMed = LocalDate.parse("2022-01-05"),
+            tilOgMed = LocalDate.parse("2022-01-01")
+        ).valider("utenlandskNæring[0]").verifiserFeil(1,
+            listOf("utenlandskNæring[0].tilOgMed må være lik eller etter fraOgMed")
+        )
+    }
+
+    @Test
+    fun `Liste med UtenlandskNæring som har feil i land gir valideringsfeil`(){
+        listOf(
+            UtenlandskNæring(
+                næringstype = Næringstyper.JORDBRUK_SKOGBRUK,
+                navnPåVirksomheten = "Flush AS",
+                land = Land("CBA", "Nederland"),
+                identifikasjonsnummer = "123ABC",
+                fraOgMed = LocalDate.parse("2022-01-01"),
+                tilOgMed = LocalDate.parse("2022-01-03")
+            ),
+            UtenlandskNæring(
+                næringstype = Næringstyper.JORDBRUK_SKOGBRUK,
+                navnPåVirksomheten = "Flush AS",
+                land = Land("ABC", "Nederland"),
+                identifikasjonsnummer = "123ABC",
+                fraOgMed = LocalDate.parse("2022-01-05")
+            )
+        ).valider("utenlandskNæring").verifiserFeil(2,
+            listOf(
+                "utenlandskNæring[0].land.Landkode 'CBA' er ikke en gyldig ISO 3166-1 alpha-3 kode.",
+                "utenlandskNæring[1].land.Landkode 'ABC' er ikke en gyldig ISO 3166-1 alpha-3 kode."
+            )
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/helse/domene/arbeid/ArbeidIPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/arbeid/ArbeidIPeriodeTest.kt
@@ -1,6 +1,6 @@
 package no.nav.helse.domene.arbeid
 
-import no.nav.helse.TestUtils.Companion.validerFeil
+import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.soknad.PlanUkedager
 import no.nav.helse.soknad.domene.arbeid.*
 import java.time.DayOfWeek
@@ -22,7 +22,7 @@ class ArbeidIPeriodeTest {
             type = ArbeidIPeriodeType.ARBEIDER_ENKELTDAGER,
             arbeiderIPerioden = ArbeiderIPeriodenSvar.REDUSERT,
             enkeltdager = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test
@@ -31,7 +31,7 @@ class ArbeidIPeriodeTest {
             type = ArbeidIPeriodeType.ARBEIDER_FASTE_UKEDAGER,
             arbeiderIPerioden = ArbeiderIPeriodenSvar.REDUSERT,
             fasteDager = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test
@@ -40,7 +40,7 @@ class ArbeidIPeriodeTest {
             type = ArbeidIPeriodeType.ARBEIDER_PROSENT_AV_NORMALT,
             arbeiderIPerioden = ArbeiderIPeriodenSvar.REDUSERT,
             prosentAvNormalt = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test
@@ -49,7 +49,7 @@ class ArbeidIPeriodeTest {
             type = ArbeidIPeriodeType.ARBEIDER_TIMER_I_SNITT_PER_UKE,
             arbeiderIPerioden = ArbeiderIPeriodenSvar.REDUSERT,
             timerPerUke = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/domene/arbeid/ArbeidsforholdTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/arbeid/ArbeidsforholdTest.kt
@@ -1,6 +1,6 @@
 package no.nav.helse.domene.arbeid
 
-import no.nav.helse.TestUtils.Companion.validerFeil
+import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.soknad.PlanUkedager
 import no.nav.helse.soknad.domene.arbeid.*
 import no.nav.k9.søknad.felles.type.Periode
@@ -33,7 +33,7 @@ class ArbeidsforholdTest {
                 type = ArbeidIPeriodeType.ARBEIDER_VANLIG,
                 arbeiderIPerioden = ArbeiderIPeriodenSvar.SOM_VANLIG
             )
-        ).valider("test").validerFeil(2)
+        ).valider("test").verifiserFeil(2)
     }
 
     @Test
@@ -48,7 +48,7 @@ class ArbeidsforholdTest {
                 arbeiderIPerioden = ArbeiderIPeriodenSvar.SOM_VANLIG,
                 enkeltdager = null
             )
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/domene/arbeid/ArbeidsgiverTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/arbeid/ArbeidsgiverTest.kt
@@ -1,6 +1,6 @@
 package no.nav.helse.domene.arbeid
 
-import no.nav.helse.TestUtils.Companion.validerFeil
+import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.soknad.Arbeidsgiver
 import no.nav.helse.soknad.domene.arbeid.*
 import no.nav.k9.søknad.felles.type.Periode
@@ -37,7 +37,7 @@ class ArbeidsgiverTest {
                     fasteDager = null
                 )
             )
-        ).valider("test").validerFeil(3)
+        ).valider("test").verifiserFeil(3)
     }
 
     @Test
@@ -89,7 +89,7 @@ class ArbeidsgiverTest {
             organisasjonsnummer = "977155436",
             erAnsatt = false,
             arbeidsforhold = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test
@@ -99,7 +99,7 @@ class ArbeidsgiverTest {
             organisasjonsnummer = "IKKE GYLDIG",
             erAnsatt = false,
             arbeidsforhold = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
 }

--- a/src/test/kotlin/no/nav/helse/domene/arbeid/NormalArbeidstidTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/arbeid/NormalArbeidstidTest.kt
@@ -1,6 +1,6 @@
 package no.nav.helse.domene.arbeid
 
-import no.nav.helse.TestUtils.Companion.validerFeil
+import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.soknad.PlanUkedager
 import no.nav.helse.soknad.domene.arbeid.NormalArbeidstid
 import org.junit.jupiter.api.assertThrows
@@ -19,7 +19,7 @@ class NormalArbeidstidTest {
             erLiktHverUke = true,
             timerPerUkeISnitt = null,
             timerFasteDager = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test
@@ -28,7 +28,7 @@ class NormalArbeidstidTest {
                 erLiktHverUke = true,
                 timerPerUkeISnitt = Duration.ofHours(37).plusMinutes(30),
                 timerFasteDager = PlanUkedager()
-            ).valider("test").validerFeil(1)
+            ).valider("test").verifiserFeil(1)
     }
 
     @Test
@@ -37,7 +37,7 @@ class NormalArbeidstidTest {
             erLiktHverUke = null,
             timerPerUkeISnitt = Duration.ofHours(37).plusMinutes(30),
             timerFasteDager = null
-        ).valider("test").validerFeil(1)
+        ).valider("test").verifiserFeil(1)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/domene/arbeid/SelvstendigArbeidsforholdTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/arbeid/SelvstendigArbeidsforholdTest.kt
@@ -1,10 +1,10 @@
 package no.nav.helse.domene.arbeid
 
-import no.nav.helse.soknad.Næringstyper.JORDBRUK_SKOGBRUK
 import no.nav.helse.soknad.Regnskapsfører
 import no.nav.helse.soknad.SelvstendigNæringsdrivende
 import no.nav.helse.soknad.Virksomhet
 import no.nav.helse.soknad.YrkesaktivSisteTreFerdigliknedeÅrene
+import no.nav.helse.soknad.domene.Næringstyper.JORDBRUK_SKOGBRUK
 import no.nav.helse.soknad.domene.arbeid.*
 import no.nav.k9.søknad.felles.type.Periode
 import java.time.Duration


### PR DESCRIPTION
Fjerner ubrukt felt i BarnRelasjon.
Flytter Næringstyper ut til felles mappe, brukes av flere klasser.
Refaktorerer Land og implementerer en validerV2 som støtter kortere og mer lesbar validering.