### PR TITLE
Bytter baseimage til Amazon Corretto 17-Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM navikt/java:17
+FROM amazoncorretto:17.0.2-alpine3.15
 
 COPY build/libs/app.jar ./
+
+CMD ["java", "-jar", "app.jar"]

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -16,15 +16,12 @@
     "login.microsoftonline.com"
   ],
   "env": {
-    "REDIS_HOST": "pleiepengesoknad-api-redis",
     "CORS_ADDRESSES": "https://pleiepengesoknad.dev.nav.no, https://sif-innsyn.dev.nav.no, https://endringsmelding-pleiepenger.dev.nav.no",
-    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navtestb2c.onmicrosoft.com/discovery/v2.0/.well-known/openid-configuration?p=b2c_1a_idporten_ver1",
     "COOKIE_NAME": "selvbetjening-idtoken",
     "K9_OPPSLAG_REGISTER_URL": "http://k9-selvbetjening-oppslag",
     "K9_MELLOMLAGRING_SERVICE_DISCOVERY": "http://k9-mellomlagring",
-    "K9_MELLOMLAGRING_INGRESS": "https://k9-mellomlagring.dev.intern.nav.no/v1/dokument",
     "K9_MELLOMLAGRING_CLIENT_ID": "8d0460bd-ea81-4b08-b524-cf04874a794c/.default",
-    "SIF_INNSYN_API_URL": "https://sif-innsyn-api.dev.nav.no",
+    "SIF_INNSYN_API_URL": "http://sif-innsyn-api",
     "K9_BRUKERDIALOG_CACHE_URL": "http://k9-brukerdialog-cache",
     "K9_BRUKERDIALOG_CACHE_TOKENX_AUDIENCE": "dev-gcp:dusseldorf:k9-brukerdialog-cache"
   },

--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -55,6 +55,7 @@ spec:
         - application: k9-mellomlagring
         - application: k9-brukerdialog-cache
         - application: k9-selvbetjening-oppslag
+        - application: sif-innsyn-api
       external:
       {{#each externalHosts as |host|}}
           - host: {{host }}

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -15,14 +15,11 @@
     "login.microsoftonline.com"
   ],
   "env": {
-    "REDIS_HOST": "pleiepengesoknad-api-redis",
     "CORS_ADDRESSES": "https://pleiepengesoknad.nav.no,https://www.nav.no",
-    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navnob2c.onmicrosoft.com/discovery/v2.0/.well-known/openid-configuration?p=b2c_1a_idporten",
     "COOKIE_NAME": "selvbetjening-idtoken",
     "K9_OPPSLAG_REGISTER_URL": "http://k9-selvbetjening-oppslag",
-    "SIF_INNSYN_API_URL": "https://sif-innsyn-api.nav.no",
+    "SIF_INNSYN_API_URL": "http://sif-innsyn-api",
     "K9_MELLOMLAGRING_SERVICE_DISCOVERY": "http://k9-mellomlagring",
-    "K9_MELLOMLAGRING_INGRESS": "https://k9-mellomlagring.intern.nav.no/v1/dokument",
     "K9_MELLOMLAGRING_CLIENT_ID": "19aaf0b2-f40a-4a64-bf7f-fd2dd62f0552/.default",
     "K9_BRUKERDIALOG_CACHE_URL": "http://k9-brukerdialog-cache",
     "K9_BRUKERDIALOG_CACHE_TOKENX_AUDIENCE": "prod-gcp:dusseldorf:k9-brukerdialog-cache"


### PR DESCRIPTION
- Sletter ubrukte miljøvariabler i pod.
- Bytter til service discovery kall mot sif-innsyn-api.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>