### PR TITLE
Cacher innsendinger i 1 minutt.

### DIFF
--- a/src/main/kotlin/no/nav/helse/App.kt
+++ b/src/main/kotlin/no/nav/helse/App.kt
@@ -57,6 +57,7 @@ import no.nav.helse.mellomlagring.mellomlagringApis
 import no.nav.helse.soker.SøkerGateway
 import no.nav.helse.soker.SøkerService
 import no.nav.helse.soker.søkerApis
+import no.nav.helse.soknad.InnsendingCache
 import no.nav.helse.soknad.SøknadService
 import no.nav.helse.soknad.soknadApis
 import no.nav.helse.vedlegg.K9MellomlagringGateway
@@ -202,7 +203,8 @@ fun Application.pleiepengesoknadapi() {
                 ),
                 barnService = barnService,
                 søkerService = søkerService,
-                vedleggService = vedleggService
+                vedleggService = vedleggService,
+                innsendingCache = InnsendingCache(expireMinutes = configuration.getInnSendingCacheExpiryMinutes())
             )
 
             endringsmeldingApis(

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -79,4 +79,8 @@ data class Configuration(val config: ApplicationConfig) {
             keyStore = keyStore
         )
     }
+
+    fun getInnSendingCacheExpiryMinutes(): Long {
+        return config.getRequiredString("nav.cache.innsending.expiry_in_minutes", secret = false).toLong()
+    }
 }

--- a/src/main/kotlin/no/nav/helse/soknad/InnsendingCache.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/InnsendingCache.kt
@@ -1,0 +1,44 @@
+package no.nav.helse.soknad
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import no.nav.helse.dusseldorf.ktor.core.DefaultProblemDetails
+import no.nav.helse.dusseldorf.ktor.core.Throwblem
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.time.Duration
+
+class InnsendingCache(expireMinutes: Long) {
+
+    private val cache: Cache<String, String> = Caffeine.newBuilder()
+        .maximumSize(1000)
+        .expireAfterWrite(Duration.ofMinutes(expireMinutes))
+        .evictionListener<String, String> { _, _, _ -> logger.info("Tømmer cache for ugått innsending.") }
+        .build()
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @kotlin.jvm.Throws(Throwblem::class)
+    fun put(key: String) {
+        if (duplikatEksisterer(key)) {
+            throw Throwblem(DuplikatInnsendingProblem())
+        }
+        cache.put(key, "") // verdi er ikke relevant. Vi er kun interessert i key.
+    }
+
+    private fun duplikatEksisterer(key: String): Boolean = when (cache.getIfPresent(key)) {
+        null -> false
+        else -> true
+    }
+}
+
+class DuplikatInnsendingProblem: DefaultProblemDetails(
+    title = "Duplikat innsending",
+    type = URI("/problem-details/duplikat-innsendin"),
+    status = 400,
+    detail = "Det ble funnet en eksisterende innsending på søker med samme ytelse.",
+    instance = URI("")
+)

--- a/src/main/kotlin/no/nav/helse/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/helse/soknad/SøknadApis.kt
@@ -32,18 +32,24 @@ fun Route.soknadApis(
     idTokenProvider: IdTokenProvider,
     barnService: BarnService,
     søkerService: SøkerService,
-    vedleggService: VedleggService
+    vedleggService: VedleggService,
+    innsendingCache: InnsendingCache
 ) {
 
     post(SØKNAD_URL) {
         val søknad = call.receive<Søknad>()
+        val idToken = idTokenProvider.getIdToken(call)
+
+        val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_PSB"
+        innsendingCache.put(cacheKey)
+
         logger.info(formaterStatuslogging(søknad.søknadId, "mottatt"))
 
         søknadService.registrer(
             søknad = søknad,
             callId = call.getCallId(),
             metadata = call.getMetadata(),
-            idToken = idTokenProvider.getIdToken(call)
+            idToken = idToken
         )
 
         call.respond(HttpStatusCode.Accepted)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -78,6 +78,9 @@ nav {
             max_size = "500"
             max_size = ${?CACHE_MAX_SIZE}
         }
+        innsending{
+          expiry_in_minutes = "1"
+        }
     }
     kafka {
           bootstrap_servers = ${?KAFKA_BROKERS}

--- a/src/test/kotlin/no/nav/helse/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/ApplicationTest.kt
@@ -42,7 +42,6 @@ import org.json.JSONObject
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
@@ -1399,7 +1398,6 @@ class ApplicationTest {
         )
     }
 
-    @Disabled
     @Nested
     inner class MellomlagringApisTest {
 

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -64,6 +64,7 @@ object TestConfiguration {
 
         map["nav.mellomlagring.søknad_tid_timer"] = "1"
         map["nav.mellomlagring.endringsmelding_tid_timer"] = "1"
+        map["nav.cache.innsending.expiry_in_minutes"] = "0"
 
         // Kafka
         kafkaEnvironment?.let {

--- a/src/test/kotlin/no/nav/helse/wiremock/K9BrukerdialogCacheResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/helse/wiremock/K9BrukerdialogCacheResponseTransformer.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.wiremock
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.tomakehurst.wiremock.common.FileSource
@@ -135,9 +136,9 @@ class K9BrukerdialogCacheResponseTransformer() : ResponseTransformer() {
     data class Cache(
         val nøkkel: String,
         val verdi: String,
-        val utløpsdato: ZonedDateTime,
-        val opprettet: ZonedDateTime? = null,
-        val endret: ZonedDateTime? = null
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC") val utløpsdato: ZonedDateTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC") val opprettet: ZonedDateTime? = null,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC") val endret: ZonedDateTime? = null
     )
 
     private fun CacheRequestDTO.somCache(nøkkel: String) = Cache(


### PR DESCRIPTION
Dette er ment å brukes til å håndtere duplikatinnsendinger. Nøkkel består søkers ident og ytelse.

Hvis det finnes en eksisterende nøkkel ved innsending vil tjenesten gi en 400 feil. Hvis ikke, vil det fungere som normalt.

Signed-off-by: Ramin Esfandiari <ramin_esfandiari_93@hotmail.com>